### PR TITLE
Get default FastRPTS entities parameters from a default xml file.

### DIFF
--- a/performance_test/resources/xml/DEFAULT_FASTRTPS_PROFILES.xml
+++ b/performance_test/resources/xml/DEFAULT_FASTRTPS_PROFILES.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<profiles>
+    <publisher profile_name="constrained_publisher" is_default_profile="true">
+        <topic>
+            <resourceLimitsQos>
+                <max_samples>20</max_samples>
+                <allocated_samples>20</allocated_samples>
+            </resourceLimitsQos>
+        </topic>
+    </publisher>
+
+    <subscriber profile_name="constrained_publisher" is_default_profile="true">
+        <topic>
+            <resourceLimitsQos>
+                <max_samples>20</max_samples>
+                <allocated_samples>20</allocated_samples>
+            </resourceLimitsQos>
+        </topic>
+    </subscriber>
+</profiles>

--- a/performance_test/src/communication_abstractions/fast_rtps_communicator.hpp
+++ b/performance_test/src/communication_abstractions/fast_rtps_communicator.hpp
@@ -156,6 +156,7 @@ public:
       const FastRTPSQOSAdapter qos(m_ec.qos());
 
       eprosima::fastrtps::PublisherAttributes wparam;
+      eprosima::fastrtps::Domain::getDefaultPublisherAttributes(wparam);
       wparam.topic.topicKind = eprosima::fastrtps::rtps::TopicKind_t::NO_KEY;
       wparam.topic.topicDataType = m_topic_type->getName();
       wparam.topic.topicName = Topic::topic_name();
@@ -192,6 +193,7 @@ public:
       const FastRTPSQOSAdapter qos(m_ec.qos());
 
       eprosima::fastrtps::SubscriberAttributes rparam;
+      eprosima::fastrtps::Domain::getDefaultSubscriberAttributes(rparam);
       rparam.topic.topicKind = eprosima::fastrtps::rtps::TopicKind_t::NO_KEY;;
       rparam.topic.topicDataType = m_topic_type->getName();
       rparam.topic.topicName = Topic::topic_name();

--- a/performance_test/src/communication_abstractions/resource_manager.cpp
+++ b/performance_test/src/communication_abstractions/resource_manager.cpp
@@ -44,6 +44,7 @@ eprosima::fastrtps::Participant * ResourceManager::fastrtps_participant() const
   eprosima::fastrtps::Participant * result = nullptr;
 
   eprosima::fastrtps::ParticipantAttributes PParam;
+  eprosima::fastrtps::Domain::getDefaultParticipantAttributes(PParam);
   PParam.rtps.defaultSendPort = 11511;
   PParam.rtps.use_IP6_to_send = true;
   PParam.rtps.sendSocketBufferSize = 1048576;


### PR DESCRIPTION
With this patch this application will be able to configure FastRTPS entities (participant, publishers and subscribers) using a default XML file (named DEFAULT_FASTRTPS_PROFILES.xml).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/performance_test/9)
<!-- Reviewable:end -->
