### PR TITLE
adding missing include path for osrf_testing_tools_cpp

### DIFF
--- a/performance_test/CMakeLists.txt
+++ b/performance_test/CMakeLists.txt
@@ -57,7 +57,7 @@ ament_export_include_directories(include)
 add_subdirectory(src/idlgen/fast_rtps)
 # This is a workaround for broken include paths on some systems.
 include_directories(${FastRTPS_INCLUDE_DIR}/fastrtps/include ${fastcdr_INCLUDE_DIR})
-include_directories(include ${FAST_RTPS_IDL_INCLUDE_DIR})
+include_directories(include ${FAST_RTPS_IDL_INCLUDE_DIR} ${osrf_testing_tools_cpp_INCLUDE_DIR})
 
 #find_package(micro_dds_cmake_module)
 #if(${micro_dds_cmake_module_FOUND_AMENT_PACKAGE})


### PR DESCRIPTION
Avoiding this error:

```
In file included from /perf_test_ws/src/performance_test/performance_test/src/experiment_execution/../data_running/data_runner_factory.hpp:21:0,
                 from /perf_test_ws/src/performance_test/performance_test/src/experiment_execution/analyze_runner.hpp:23,
                 from /perf_test_ws/src/performance_test/performance_test/src/experiment_execution/analyze_runner.cpp:15:
/perf_test_ws/src/performance_test/performance_test/src/experiment_execution/../data_running/data_runner_base.hpp: In member function ‘void performance_test::DataRunnerBase::assert_memory_tools_is_working()’:
/perf_test_ws/src/performance_test/performance_test/src/experiment_execution/../data_running/data_runner_base.hpp:107:5: error: ‘osrf_testing_tools_cpp’ has not been declared
     osrf_testing_tools_cpp::memory_tools::on_malloc(on_malloc_cb);
     ^~~~~~~~~~~~~~~~~~~~~~
/perf_test_ws/src/performance_test/performance_test/src/experiment_execution/../data_running/data_runner_base.hpp:108:39: error: ‘osrf_testing_tools_cpp’ has not been declared
     OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(osrf_testing_tools_cpp::memory_tools::on_malloc(nullptr));
                                       ^~~~~~~~~~~~~~~~~~~~~~
/perf_test_ws/src/performance_test/performance_test/src/experiment_execution/../data_running/data_runner_base.hpp:108:5: error: ‘OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT’ was not declared in this scope
     OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(osrf_testing_tools_cpp::memory_tools::on_malloc(nullptr));
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/performance_test/13)
<!-- Reviewable:end -->
