### PR TITLE
resolve memory plotting issue

### DIFF
--- a/performance_test/helper_scripts/performance_test_file_reader.py
+++ b/performance_test/helper_scripts/performance_test_file_reader.py
@@ -22,12 +22,10 @@ def parse_file(file, single_file=None):
 
         if not dataframe.empty:
             pd.options.display.float_format = '{:.4f}'.format
-            dataframe = dataframe.iloc[10:]
-            dataframe["maxrss"] = dataframe["ru_maxrss"] / 1e3
+            # ru_maxrss is in KB: http://man7.org/linux/man-pages/man2/getrusage.2.html. Converting to Mb
+            dataframe["maxrss (Mb)"] = dataframe["ru_maxrss"] / 1e3
             dataframe.drop(list(dataframe.filter(regex='ru_')), axis=1, inplace=True)
             dataframe["latency_variance (ms) * 100"] = 100.0 * dataframe["latency_variance (ms)"]
-            # ru_maxrss is in KB: http://man7.org/linux/man-pages/man2/getrusage.2.html. Converting to Mb
-            dataframe["maxrss (Mb)"] = dataframe["maxrss"] / 1e3
             dataframe[["T_experiment",
                        "latency_min (ms)",
                        "latency_max (ms)",


### PR DESCRIPTION
resolve memory plotting issue
Don't double divide memory usage by 1e3 and don't skip first 10 elements in the table.
follow up to d7e03059e4e9ca23a3e940e354966c6efe725ffa

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/performance_test/15)
<!-- Reviewable:end -->
