### PR TITLE
fix the intraprocess flag name

### DIFF
--- a/performance_test/src/experiment_configuration/experiment_configuration.cpp
+++ b/performance_test/src/experiment_configuration/experiment_configuration.cpp
@@ -173,7 +173,7 @@ void ExperimentConfiguration::setup(int argc, char ** argv)
     }
 
     m_use_ros_shm = false;
-    if (vm.count("use_ros2_shm")) {
+    if (vm.count("use_ros_shm")) {
       if (m_com_mean != CommunicationMean::ROS2) {
         throw std::invalid_argument("Must use ROS2 for this option for ROS2 SHM!");
       }


### PR DESCRIPTION
The check here is inconsistent with the option declared in the command line which means it could never be triggered, and the command line option wouldn't do anything.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/performance_test/16)
<!-- Reviewable:end -->
