### PR TITLE
Security integration

### DIFF
--- a/performance_test/helper_scripts/policies.yaml
+++ b/performance_test/helper_scripts/policies.yaml
@@ -1,0 +1,26 @@
+nodes:
+  performance_test0:
+   topics:
+     '*':
+       allow: ps # can publish/subscribe to any topics
+  performance_test1:
+   topics:
+     '*':
+       allow: ps # can publish/subscribe to any topics
+  performance_test2:
+   topics:
+     '*':
+       allow: ps # can publish/subscribe to any topics
+  performance_test3: 
+   topics:
+     '*':
+       allow: ps # can publish/subscribe to any topics
+  performance_test4:
+   topics:
+     '*':
+       allow: ps # can publish/subscribe to any topics
+  performance_test5:
+   topics:
+     '*':
+       allow: ps # can publish/subscribe to any topics
+

--- a/performance_test/helper_scripts/security_setup.sh
+++ b/performance_test/helper_scripts/security_setup.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -e
+
+# help
+if [ "$1" = "--help" ] || [ -z "$1" ] ; then
+  echo "Usage: enable_security <root_directory_to_keys> <enable/disable>"
+  echo "Example usage: "
+  echo "echo enable_security '~/ApexOS/apex_ws/demo_keys' enable"
+  exit 0
+fi
+
+
+if [ $2 == 'enable' ]
+then 
+  echo 'enabling security'
+
+  max_nodes=5
+
+  source ~/ApexOS/apex_ws/install/setup.bash  
+
+  # create keys
+  ros2 security create_keystore "$1"
+
+  for ((i=0; i<=$max_nodes; i++))
+  do
+    node=performance_test$i
+    echo "generating keys for "$node
+    echo $1
+    ros2 security create_key "$1" "$node"
+    ros2 security create_permission "$1" "$node" policies.yaml;  
+    echo " "
+  done 
+
+  #enable security
+  export ROS_SECURITY_ENABLE=true 
+  export ROS_SECURITY_STRATEGY=Enforce 
+  export ROS_SECURITY_ROOT_DIRECTORY=$1 
+  source ~/ApexOS/apex_ws/install/setup.bash
+else 
+  echo 'diabling security'
+  #disable security
+  unset ROS_SECURITY_ENABLE 
+  unset ROS_SECURITY_STRATEGY 
+  unset ROS_SECURITY_ROOT_DIRECTORY
+  echo 'security disabled'
+fi
+
+
+

--- a/performance_test/helper_scripts/security_setup.sh
+++ b/performance_test/helper_scripts/security_setup.sh
@@ -1,49 +1,53 @@
 #!/bin/bash
 
+
 set -e
 
 # help
-if [ "$1" = "--help" ] || [ -z "$1" ] ; then
-  echo "Usage: enable_security <root_directory_to_keys> <enable/disable>"
+if [ "$1" = "--help" ] || [ -z "$1" ] || [[ "$1" == "enable" && -z "$2" ]] || [[ "$1" != "disable" && "$1" != "enable" ]]
+then
+#  ; then
+  echo "Usage: setup_security <enable/disable> <root_directory_to_keys>"
+  echo "directory to keys is required when security is enabled"
   echo "Example usage: "
-  echo "echo enable_security '~/ApexOS/apex_ws/demo_keys' enable"
+  echo "To enable the security: "
+  echo "bash setup_security.sh enable '/ApexOS/apex_ws/demo_keys'"
+  echo "To disable the security: "
+  echo "bash setup_security.sh disable"
   exit 0
 fi
 
-
-if [ $2 == 'enable' ]
+if [ "$1" == "enable" ]
 then 
-  echo 'enabling security'
+  echo 'generating keys'
 
   max_nodes=5
 
   source ~/ApexOS/apex_ws/install/setup.bash  
 
   # create keys
-  ros2 security create_keystore "$1"
+  ros2 security create_keystore "$2"
 
   for ((i=0; i<=$max_nodes; i++))
   do
     node=performance_test$i
     echo "generating keys for "$node
-    echo $1
-    ros2 security create_key "$1" "$node"
-    ros2 security create_permission "$1" "$node" policies.yaml;  
+    ros2 security create_key "$2" "$node"
+    ros2 security create_permission "$2" "$node" policies.yaml;  
     echo " "
   done 
 
   #enable security
-  export ROS_SECURITY_ENABLE=true 
-  export ROS_SECURITY_STRATEGY=Enforce 
-  export ROS_SECURITY_ROOT_DIRECTORY=$1 
   source ~/ApexOS/apex_ws/install/setup.bash
-else 
-  echo 'diabling security'
+  echo "run this line to enable security"
+  echo "export ROS_SECURITY_ENABLE=true && export ROS_SECURITY_STRATEGY=Enforce && export ROS_SECURITY_ROOT_DIRECTORY=$2"
+elif [ "$1" == "disable" ]
+then 
+  echo "run this line to disable security"
   #disable security
-  unset ROS_SECURITY_ENABLE 
-  unset ROS_SECURITY_STRATEGY 
-  unset ROS_SECURITY_ROOT_DIRECTORY
-  echo 'security disabled'
+  echo "unset ROS_SECURITY_ENABLE && unset ROS_SECURITY_STRATEGY && unset ROS_SECURITY_ROOT_DIRECTORY"
+else 
+  echo 'incorrect parameter '$2
 fi
 
 

--- a/performance_test/src/communication_abstractions/resource_manager.cpp
+++ b/performance_test/src/communication_abstractions/resource_manager.cpp
@@ -33,7 +33,14 @@ std::shared_ptr<rclcpp::Node> ResourceManager::ros2_node() const
 //    }
 //    return m_node;
 
-  std::string rand_str = std::to_string(std::rand());
+  std::string rand_str;
+  // if security is enabled
+  if (m_ec.is_with_security()) {
+    static uint32_t id=0;
+    rand_str = std::to_string(id++);
+  } else {
+    rand_str = std::to_string(std::rand());
+  }
   return rclcpp::Node::make_shared("performance_test" + rand_str, "", m_ec.use_ros_shm());
 }
 

--- a/performance_test/src/experiment_configuration/experiment_configuration.cpp
+++ b/performance_test/src/experiment_configuration/experiment_configuration.cpp
@@ -83,7 +83,8 @@ void ExperimentConfiguration::setup(int argc, char ** argv)
     ("use_drive_px_rt", "Enable RT. Only the Drive PX has the right configuration to support this.")(
     "use_single_participant", "Uses only one participant per process. By default every thread has its own.")
     ("no_waitset", "Disables the wait set for new data. The subscriber takes as fast as possible.")(
-    "no_micro_intra", "Disables the Connext DDS Micro INTRA transport.")
+    "no_micro_intra", "Disables the Connext DDS Micro INTRA transport.")(
+      "with_security", "Enables the security with ROS2")
   ;
   po::variables_map vm;
   po::store(parse_command_line(argc, argv, desc), vm);
@@ -209,6 +210,15 @@ void ExperimentConfiguration::setup(int argc, char ** argv)
         m_no_micro_intra = true;
       }
     }
+    m_with_security = false;
+    if (vm.count("with_security")) {
+      if (m_com_mean != CommunicationMean::ROS2) {
+        throw std::invalid_argument(
+            "Only ROS2 supports security!");
+      } else {
+        m_with_security = true;
+      }
+    }
     m_is_setup = true;
 
     // Logfile needs to be opened at the end, as the experiment configuration influences the
@@ -300,6 +310,12 @@ bool ExperimentConfiguration::no_micro_intra() const
 {
   check_setup();
   return m_no_micro_intra;
+}
+
+bool ExperimentConfiguration::is_with_security() const
+{
+  check_setup();
+  return m_with_security;
 }
 
 

--- a/performance_test/src/experiment_configuration/experiment_configuration.hpp
+++ b/performance_test/src/experiment_configuration/experiment_configuration.hpp
@@ -101,6 +101,9 @@ public:
   /// \returns Returns if Connext DSS Micro INTRA transport should be disabled. This will throw if
   /// the experiment configuration is not set up.
   bool no_micro_intra() const;
+  /// \returns Returns if security is enabled for ROS2. This will throw if the configured mean
+  ///  of communication is not ROS2
+  bool is_with_security() const;
   /// \returns Returns the randomly generated unique ID of the experiment. This will throw if the
   /// experiment configuration is not set up.
   boost::uuids::uuid id() const;
@@ -157,6 +160,7 @@ private:
   bool m_use_single_participant;
   bool m_no_waitset;
   bool m_no_micro_intra;
+  bool m_with_security;
 };
 
 /// Outstream operator for ExperimentConfiguration.


### PR DESCRIPTION
This enables security over ROS2.

Steps to test:
1. Build with flags `-DSECURITY=ON`
2. run the script to enable security
```sh
$ cd performance_test/performance_test/helper_scripts/
$ bash security_setup.sh enable 'ApexOS/apex_ws/demo_keys '
```
3. run the performance test with flag `with_security`, for example
```sh
$ ros2 run performance_test perf_test -c ROS2 -l log -t Array1k --max_runtime 10 --with_security
```

Once the test is done disable the security
```sh
$ cd performance_test/performance_test/helper_scripts/
$ bash security_setup.sh disable
```

Change the `policies.yaml` to diable or enable topics. (for now this only works for 5 performance _test nodes)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/performance_test/17)
<!-- Reviewable:end -->
