### PR TITLE
allow users to generate .pdf result file without running X server

### DIFF
--- a/performance_test/helper_scripts/performance_test_file_reader.py
+++ b/performance_test/helper_scripts/performance_test_file_reader.py
@@ -20,6 +20,7 @@ import sys
 import numpy as np
 import pandas as pd
 import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt # noqa:
 import matplotlib.backends.backend_pdf
 


### PR DESCRIPTION
In case X11 is not enabled and without users to configure Matplotlib, use agg backend as default. #21

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/performance_test/22)
<!-- Reviewable:end -->
