### PR TITLE
Added roundtrip mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ python src/performance_test/performance_test/helper_scripts/run_experiment.py
 
 You need to edit the python script to call the performance test tool with the desired parameters.
 
+# Relay mode
+
+Testing latency between multiple machines is difficult as it is hard precisely synchronize clocks between them.
+To overcome this issue performance test supports relay mode which allows for a round-trip style of communication.
+
+On the main machine: `ros2 run performance_test -c ROS2 -t Array1k --roundtrip_mode Main`
+On the relay machine: `ros2 run performance_test -c ROS2 -t Array1k --roundtrip_mode Relay`
+
+Note that on the main machine the round trip latency is reported and will be roughly double the latency compared to
+the latency reported in non-relay mode.
+
 # Memory analysis
 
 You can use OSRF memory tools to find memory allocations in your application. To enable it

--- a/performance_test/src/communication_abstractions/connext_dds_micro_communicator.hpp
+++ b/performance_test/src/communication_abstractions/connext_dds_micro_communicator.hpp
@@ -242,6 +242,11 @@ public:
         }
       }
       unlock();
+
+      if(m_ec.roundtrip_mode() == ExperimentConfiguration::RoundTripMode::RELAY) {
+        throw std::runtime_error("Round trip mode is not implemented for Connext DDS Micro!");
+      }
+
       m_typed_datareader->return_loan(m_data_seq,
         m_sample_info_seq);
     }

--- a/performance_test/src/communication_abstractions/fast_rtps_communicator.hpp
+++ b/performance_test/src/communication_abstractions/fast_rtps_communicator.hpp
@@ -157,7 +157,7 @@ public:
 
       eprosima::fastrtps::PublisherAttributes wparam;
       wparam.topic.topicKind = eprosima::fastrtps::rtps::TopicKind_t::NO_KEY;
-      wparam.topic.topicDataType = m_topic_type->getName();
+      wparam.topic.topicDataType = m_topic_type->getName()+m_ec.pub_topic_postfix();
       wparam.topic.topicName = Topic::topic_name();
       wparam.topic.historyQos.kind = qos.history_kind();
       wparam.topic.historyQos.depth = qos.history_depth();
@@ -193,7 +193,7 @@ public:
 
       eprosima::fastrtps::SubscriberAttributes rparam;
       rparam.topic.topicKind = eprosima::fastrtps::rtps::TopicKind_t::NO_KEY;
-      rparam.topic.topicDataType = m_topic_type->getName();
+      rparam.topic.topicDataType = m_topic_type->getName()+m_ec.sub_topic_postfix();
       rparam.topic.topicName = Topic::topic_name();
       rparam.topic.historyQos.kind = qos.history_kind();
       rparam.topic.historyQos.depth = qos.history_depth();
@@ -218,10 +218,18 @@ public:
           );
         }
 
-        m_prev_timestamp = m_data.time_();
-        update_lost_samples_counter(m_data.id_());
-        add_latency_to_statistics(m_data.time_());
-        increment_received();
+
+        if(m_ec.roundtrip_mode() == ExperimentConfiguration::RoundTripMode::RELAY) {
+          unlock();
+          publish(m_data, std::chrono::nanoseconds(m_data.time_()));
+          lock();
+        }
+        else {
+          m_prev_timestamp = m_data.time_();
+          update_lost_samples_counter(m_data.id_());
+          add_latency_to_statistics(m_data.time_());
+          increment_received();
+        }
       }
     }
     unlock();

--- a/performance_test/src/data_running/data_runner.hpp
+++ b/performance_test/src/data_running/data_runner.hpp
@@ -135,7 +135,8 @@ private:
     while (m_run) {
       const auto next_run = std::chrono::steady_clock::now() +
         std::chrono::duration<double>(1.0 / m_ec.rate());
-      if (m_run_type == RunType::PUBLISHER) {
+
+      if (m_run_type == RunType::PUBLISHER && m_ec.roundtrip_mode() != ExperimentConfiguration::RoundTripMode::RELAY) {
         std::chrono::nanoseconds epoc_time =
           std::chrono::steady_clock::now().time_since_epoch();
         m_com.publish(data, epoc_time);
@@ -151,7 +152,10 @@ private:
         m_time_reserve_statistics.add_sample(reserve.count());
         m_lock.unlock();
       }
-      if (m_ec.rate() > 0 && m_run_type == RunType::PUBLISHER) {
+      if (m_ec.rate() > 0 &&
+          m_run_type == RunType::PUBLISHER &&
+          // Relays should never sleep.
+          m_ec.roundtrip_mode() != ExperimentConfiguration::RoundTripMode::RELAY) {
         std::this_thread::sleep_until(next_run);
       }
 

--- a/performance_test/src/experiment_configuration/experiment_configuration.cpp
+++ b/performance_test/src/experiment_configuration/experiment_configuration.cpp
@@ -29,6 +29,18 @@
 namespace performance_test
 {
 
+std::ostream & operator<<(std::ostream & stream, const ExperimentConfiguration::RoundTripMode & e) {
+  if(e == ExperimentConfiguration::RoundTripMode::NONE) {
+    stream << "NONE";
+  }
+  else if(e == ExperimentConfiguration::RoundTripMode::MAIN) {
+    stream << "MAIN";
+  }
+  else if(e == ExperimentConfiguration::RoundTripMode::RELAY) {
+    stream << "RELAY";
+  }
+  return stream;
+}
 std::ostream & operator<<(std::ostream & stream, const ExperimentConfiguration & e)
 {
   if (e.is_setup()) {
@@ -47,7 +59,9 @@ std::ostream & operator<<(std::ostream & stream, const ExperimentConfiguration &
            "\nUse ros SHM: " << e.use_ros_shm() <<
            "\nUse single participant: " << e.use_single_participant() <<
            "\nNot using waitset: " << e.no_waitset() <<
-           "\nNot using Connext DDS Micro INTRA: " << e.no_micro_intra();
+           "\nNot using Connext DDS Micro INTRA: " << e.no_micro_intra() <<
+           "\nWith security: " << e.is_with_security() <<
+           "\nRoundtrip Mode: " << e.roundtrip_mode();
   } else {
     return stream << "ERROR: Experiment is not yet setup!";
   }
@@ -87,7 +101,8 @@ void ExperimentConfiguration::setup(int argc, char ** argv)
     "Uses only one participant per process. By default every thread has its own.")("no_waitset",
     "Disables the wait set for new data. The subscriber takes as fast as possible.")(
     "no_micro_intra", "Disables the Connext DDS Micro INTRA transport.")(
-    "with_security", "Enables the security with ROS2")
+    "with_security", "Enables the security with ROS2")("roundtrip_mode",
+    po::value<std::string>()->default_value("None"),"Selects the round trip mode (None, Main, Relay).")
   ;
   po::variables_map vm;
   po::store(parse_command_line(argc, argv, desc), vm);
@@ -121,6 +136,11 @@ void ExperimentConfiguration::setup(int argc, char ** argv)
 
     if (vm["communication"].as<std::string>() == "ROS2") {
       m_com_mean = CommunicationMean::ROS2;
+
+#ifndef PERFORMANCE_TEST_USE_ROS2
+      throw std::invalid_argument(
+              "You must compile with ROS2 support to enable ROS2 as communication mean.");
+#endif
     } else if (vm["communication"].as<std::string>() == "FastRTPS") {
 #ifdef PERFORMANCE_TEST_FASTRTPS_ENABLED
       m_com_mean = CommunicationMean::FASTRTPS;
@@ -226,6 +246,22 @@ void ExperimentConfiguration::setup(int argc, char ** argv)
         m_with_security = true;
       }
     }
+    m_roundtrip_mode = RoundTripMode::NONE;
+    if(vm.count("roundtrip_mode")) {
+      const auto mode = vm["roundtrip_mode"].as<std::string>();
+      if(mode == "None") {
+        m_roundtrip_mode = RoundTripMode::NONE;
+      }
+      else if(mode == "Main") {
+        m_roundtrip_mode = RoundTripMode::MAIN;
+      }
+      else if(mode == "Relay") {
+        m_roundtrip_mode = RoundTripMode::RELAY;
+      }
+      else {
+        throw std::invalid_argument("Invalid roundtrip mode: " + mode);
+      }
+    }
     m_is_setup = true;
 
     // Logfile needs to be opened at the end, as the experiment configuration influences the
@@ -325,6 +361,34 @@ bool ExperimentConfiguration::is_with_security() const
   return m_with_security;
 }
 
+ExperimentConfiguration::RoundTripMode ExperimentConfiguration::roundtrip_mode() const {
+  check_setup();
+  return m_roundtrip_mode;
+}
+
+std::string ExperimentConfiguration::pub_topic_postfix() const {
+  check_setup();
+  std::string fix;
+  if(m_roundtrip_mode == ExperimentConfiguration::RoundTripMode::MAIN) {
+    fix = "main";
+  }
+  else if(m_roundtrip_mode == ExperimentConfiguration::RoundTripMode::RELAY) {
+    fix = "relay";
+  }
+  return fix;
+}
+
+std::string ExperimentConfiguration::sub_topic_postfix() const {
+  check_setup();
+  std::string fix;
+  if(m_roundtrip_mode == ExperimentConfiguration::RoundTripMode::MAIN) {
+    fix = "relay";
+  }
+  else if(m_roundtrip_mode == ExperimentConfiguration::RoundTripMode::RELAY) {
+    fix = "main";
+  }
+  return fix;
+}
 
 boost::uuids::uuid ExperimentConfiguration::id() const
 {

--- a/performance_test/src/experiment_configuration/experiment_configuration.hpp
+++ b/performance_test/src/experiment_configuration/experiment_configuration.hpp
@@ -53,6 +53,13 @@ public:
 
   ExperimentConfiguration & operator=(ExperimentConfiguration &&) = delete;
 
+  /// Specifies the selected roundtrip mode.
+  enum RoundTripMode {
+    NONE, /// No roundtrip. Samples are only sent from sender to reciever.
+    MAIN, /// Sends packages to the relay and receives packages from the relay.
+    RELAY /// Relays packages from MAIN back to MAIN.
+  };
+
   /**
    * \brief Derives an experiment configuration from command line arguments.
    * \param argc The argc parameter from the main function.
@@ -103,6 +110,12 @@ public:
   /// \returns Returns if security is enabled for ROS2. This will throw if the configured mean
   ///  of communication is not ROS2
   bool is_with_security() const;
+  /// \returns Returns the roundtrip mode.
+  RoundTripMode roundtrip_mode() const;
+  /// \returns Returns the publishing topic postfix
+  std::string pub_topic_postfix() const;
+  /// \returns Returns the subscribing topic postfix
+  std::string sub_topic_postfix() const;
   /// \returns Returns the randomly generated unique ID of the experiment. This will throw if the
   /// experiment configuration is not set up.
   boost::uuids::uuid id() const;
@@ -127,7 +140,8 @@ private:
     m_use_ros_shm(false),
     m_use_single_participant(false),
     m_no_waitset(false),
-    m_no_micro_intra(false)
+    m_no_micro_intra(false),
+    m_roundtrip_mode(RoundTripMode::NONE)
   {}
 
   /// Throws #std::runtime_error if the experiment is not set up.
@@ -160,7 +174,13 @@ private:
   bool m_no_waitset;
   bool m_no_micro_intra;
   bool m_with_security;
+
+  RoundTripMode m_roundtrip_mode;
 };
+
+/// Outstream operator for RoundTripMode.
+  std::ostream & operator<<(std::ostream & stream, const ExperimentConfiguration::RoundTripMode & e);
+
 
 /// Outstream operator for ExperimentConfiguration.
 std::ostream & operator<<(std::ostream & stream, const ExperimentConfiguration & e);


### PR DESCRIPTION
This patch adds a round trip mode to enable performance testing between machines without worrying about synchronizing clocks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/performance_test/26)
<!-- Reviewable:end -->
