### PR TITLE
Fix build error due to missing includes

### DIFF
--- a/performance_test/CMakeLists.txt
+++ b/performance_test/CMakeLists.txt
@@ -62,7 +62,7 @@ if(PERFORMANCE_TEST_FASTRTPS_ENABLED)
 endif()
 
 # This is a workaround for broken include paths on some systems.
-include_directories(${FastRTPS_INCLUDE_DIR}/fastrtps/include ${fastcdr_INCLUDE_DIR})
+include_directories(${FastRTPS_INCLUDE_DIR} ${FastRTPS_INCLUDE_DIR}/fastrtps/include ${fastcdr_INCLUDE_DIR})
 include_directories(include ${FAST_RTPS_IDL_INCLUDE_DIR} ${osrf_testing_tools_cpp_INCLUDE_DIR})
 
 #find_package(micro_dds_cmake_module)


### PR DESCRIPTION
fatal error: fastrtps/participant/Participant.h: No such file or directory
fatal error: fastrtps/TopicDataType.h: No such file or directory

The build fails due to incorrect include directory. "fastrtps/include" is
already part of FastRTPS_INCLUDE_DIR, no need to append.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/performance_test/27)
<!-- Reviewable:end -->
