### PR TITLE
Fix build error if osrf_testing_tools_cpp not found

### DIFF
--- a/performance_test/src/data_running/data_runner_base.hpp
+++ b/performance_test/src/data_running/data_runner_base.hpp
@@ -100,6 +100,7 @@ protected:
     std::free(some_memory);
   }
 
+#ifdef PERFORMANCE_TEST_MEMORYTOOLS_ENABLED
   void assert_memory_tools_is_working()
   {
     bool saw_malloc = false;
@@ -118,6 +119,8 @@ protected:
               "properly set it up.");
     }
   }
+#endif
+
 };
 
 }  // namespace performance_test

--- a/performance_test/src/data_running/data_runner_base.hpp
+++ b/performance_test/src/data_running/data_runner_base.hpp
@@ -120,7 +120,6 @@ protected:
     }
   }
 #endif
-
 };
 
 }  // namespace performance_test


### PR DESCRIPTION
Checking `PERFORMANCE_TEST_MEMORYTOOLS_ENABLED` before defining `assert_memory_tools_is_working`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/performance_test/52)
<!-- Reviewable:end -->
