### PR TITLE
Added Azure Pipelines as CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# Build Status
+[![Build Status](https://dev.azure.com/ApexAI/performance_test/_apis/build/status/ApexAI.performance_test?branchName=master)](https://dev.azure.com/ApexAI/performance_test/_build/latest?definitionId=2&branchName=master)
+
 # Introduction
 
 **Version Support:** ROS2 Crystal, Fast-RTPS 1.7.0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,38 @@
+trigger:
+  branches:
+    include:
+    - master
+  paths:
+    exclude:
+    - README.md
+
+container:
+  image: osrf/ros:crystal-desktop
+  options: "--name ci-container -v /usr/bin/docker:/tmp/docker:ro"
+
+steps:
+  - script: |
+      /tmp/docker exec -t -u 0 ci-container \
+      sh -c "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confold" -y install sudo"
+    displayName: Set up sudo
+  - script: sudo apt-get update && sudo apt-get install -y ros-crystal-osrf-testing-tools-cpp default-jre
+    displayName: Install APT dependencies
+  - script: sudo apt-get install -y python3-colcon-common-extensions
+    displayName: Install colcon
+  - script: rosdep update && rosdep install -y --from performance_test --ignore-src
+    displayName: Install ROS dependencies
+  - script: |
+      source /opt/ros/crystal/setup.bash && \
+      colcon build \
+        --merge-install \
+        --cmake-args \
+          -DCMAKE_BUILD_TYPE=Release \
+        --base-path performance_test
+    displayName: Build performance_test
+  - script: |
+      source /opt/ros/crystal/setup.bash && \
+      colcon test \
+        --merge-install \
+        --base-path performance_test && \
+      colcon test-result --verbose
+    displayName: Test performance_test

--- a/performance_test/package.xml
+++ b/performance_test/package.xml
@@ -11,12 +11,11 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <build_depend>benchmark_msgs</build_depend>
   <build_depend>builtin_interfaces</build_depend>
   <build_depend>fastrtps_cmake_module</build_depend>
   <build_depend>osrf_testing_tools_cpp</build_depend>
   <build_depend>rclcpp</build_depend>
-  <build_depend>rmw_fastrtps</build_depend>
+  <build_depend>rmw_fastrtps_cpp</build_depend>
   <build_depend>rmw_implementation_cmake</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>


### PR DESCRIPTION
Gitlab CI for GitHub projects will be phased out in a few months. Azure Pipelines seems to be well integrated with GitHub as both products are part of the same company (Microsoft).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/performance_test/58)
<!-- Reviewable:end -->
