### PR TITLE
Allowing configuration of RT priority and cpus.

### DIFF
--- a/performance_test/src/experiment_configuration/experiment_configuration.cpp
+++ b/performance_test/src/experiment_configuration/experiment_configuration.cpp
@@ -94,9 +94,11 @@ void ExperimentConfiguration::setup(int argc, char ** argv)
     "Use Ros SHM support.")("check_memory",
     "Prints backtrace of all memory operations performed by the middleware. "
     "This will slow down the application!")("use_rt_prio", po::value<int32_t>()->default_value(0),
-    "Set RT priority. Only certain platforms (i.e. Drive PX) have the right configuration to support this.")(
+    "Set RT priority. "
+    "Only certain platforms (i.e. Drive PX) have the right configuration to support this.")(
     "use_rt_cpus", po::value<uint32_t>()->default_value(0),
-    "Set RT cpu affinity mask. Only certain platforms (i.e. Drive PX) have the right configuration to support this.")(
+    "Set RT cpu affinity mask. "
+    "Only certain platforms (i.e. Drive PX) have the right configuration to support this.")(
     "use_drive_px_rt", "alias for --use_rt_prio 5 --use_rt_cpus 62")(
     "use_single_participant",
     "Uses only one participant per process. By default every thread has its own.")("no_waitset",


### PR DESCRIPTION
This PR turns `use_drive_px_rt` argument into two new arguments `use_rt_prio` and `use_rt_cpus`. It keeps the old argument as an alias to be backward compatible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/performance_test/64)
<!-- Reviewable:end -->
