### PR TITLE
generate and load default XML file to configure whitelists

### DIFF
--- a/performance_test/helper_scripts/generate_apex_xml.py
+++ b/performance_test/helper_scripts/generate_apex_xml.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+
+# Copyright 2017 Apex.AI, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generate DEFAULT XML file for apex tests."""
+import argparse
+from xml.dom.minidom import parseString
+
+from dicttoxml import dicttoxml
+
+
+def item_names(parent_name):
+    """
+    Get the tag of an item based on its parent.
+
+    :param parent_name: The name of the parent.
+    :return: The item tag.
+    """
+    if parent_name == 'interfaceWhiteList':
+        return 'address'
+    elif parent_name == 'transport_descriptors':
+        return 'transport_descriptors'
+
+
+if __name__ == '__main__':
+    # Get arguments
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument(
+        '-w',
+        '--whitelist',
+        help='List of whitelist interfaces separated by comma with no spaces',
+        required=True,
+    )
+    parser.add_argument(
+        '-f',
+        '--file',
+        help='Path to the file to store the XML',
+        required=True,
+    )
+    args = parser.parse_args()
+    interface_whitelist = args.whitelist.split(',')
+    xml_file = args.file
+
+    profiles = {
+        'transport_descriptors': {
+                'transport_descriptor': {
+                    'transport_id': 'apex_transport_descriptor',
+                    'type': 'UDPv4',
+                    'interfaceWhiteList': interface_whitelist,
+                },
+        },
+        'participant': {
+            'rtps': {
+                'name': 'Apex participant profile',
+                'useBuiltinTransports': 'false',
+                'userTransports': {
+                    'transport_id': 'apex_transport_descriptor',
+                },
+            },
+        },
+    }
+
+    xml = parseString(
+        dicttoxml(
+            profiles,
+            item_func=item_names,
+            custom_root='profiles',
+            attr_type=False,
+        ).decode()
+    ).toprettyxml(indent='    ')
+    parsed_xml = xml.split('\n', 1)[1]
+    lines = parsed_xml.split('\n')
+
+    with open(xml_file, 'w') as f:
+        for line in lines:
+            if line == '':
+                continue
+            line = line.replace(
+                '<participant',
+                (
+                    '<participant profile_name="apex_profile"' +
+                    ' is_default_profile="true"'
+                )
+            )
+            f.write('{}\n'.format(line))

--- a/performance_test/helper_scripts/generate_apex_xml.py
+++ b/performance_test/helper_scripts/generate_apex_xml.py
@@ -171,4 +171,4 @@ if __name__ == '__main__':
     with open(xml_file, 'w') as f:
         # Convert to string with 2-space identation,
         # not taking the first line of the XML.
-        f.write(doc.toprettyxml(indent=' '*2).split('\n', 1)[1])
+        f.write(doc.toprettyxml(indent=' '*2))

--- a/performance_test/helper_scripts/generate_apex_xml.py
+++ b/performance_test/helper_scripts/generate_apex_xml.py
@@ -14,11 +14,74 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Generate DEFAULT XML file for apex tests."""
-import argparse
-from xml.dom.minidom import parseString
+"""
+Generate DEFAULT XML file for apex tests.
 
-from dicttoxml import dicttoxml
+Helper script to generate a DEFAULT_FASTRTPS_PROFILES.xml XML file to add an
+interface whitelist to be used in the Fast-RTPS communication plugin. The
+script takes two optional arguments: a list of IP addresses (to create the
+interface whitelist), and a directory to place the resulting
+DEFAULT_FASTRTPS_PROFILES.xml (this directory defaults to the current
+directory).
+
+:Usage:
+    generate_apex_xml.py [-h] [-w WHITELIST [WHITELIST ...]] [-d DIRECTORY]
+
+    optional arguments:
+    -h, --help            show this help message and exit
+    -w WHITELIST [WHITELIST ...], --whitelist WHITELIST [WHITELIST ...]
+                            List of whitelist interfaces separated by spaces
+                            (default: None)
+    -d DIRECTORY, --directory DIRECTORY
+                            Directory to store the XML file (default: .)
+
+:Example:
+    generate_apex_xml.py -w 192.168.1.1 127.0.0.1 -f some_directory
+
+    The previous command would place a DEFAULT_FASTRTPS_PROFILES.xml file in
+    the 'some_directory' directory. The resulting output would be:
+        <profiles>
+        <transport_descriptors>
+            <transport_descriptor>
+            <transport_id>apex_transport_descriptor</transport_id>
+            <type>UDPv4</type>
+            <interfaceWhiteList>
+                <address>192.168.1.11</address>
+                <address>127.0.0.1</address>
+            </interfaceWhiteList>
+            </transport_descriptor>
+        </transport_descriptors>
+        <participant is_default_profile="true" profile_name="apex_profile">
+            <rtps>
+            <name>Apex participant profile</name>
+            <useBuiltinTransports>false</useBuiltinTransports>
+            <userTransports>
+                <transport_id>apex_transport_descriptor</transport_id>
+            </userTransports>
+            </rtps>
+        </participant>
+        </profiles>
+"""
+import argparse
+import os
+from xml.dom.minidom import Document
+
+
+def directory_type(directory):
+    """
+    Check whether the argument is a directory.
+
+    :param directory: The directory path.
+    :return: The directory path without ending /.
+    :raise: argparse.ArgumentTypeError if the argument is not a directory.
+    """
+    if directory.endswith('/'):
+        directory = directory[:-1]
+    if not os.path.isdir(directory):
+        raise argparse.ArgumentTypeError(
+            'Cannot find directory "{}"'.format(directory)
+        )
+    return directory
 
 
 if __name__ == '__main__':
@@ -28,54 +91,84 @@ if __name__ == '__main__':
     parser.add_argument(
         '-w',
         '--whitelist',
-        nargs='*',
+        nargs='+',
         help='List of whitelist interfaces separated by spaces',
-        required=True,
+        required=False,
     )
     parser.add_argument(
-        '-f',
-        '--file',
-        help='Path to the file to store the XML',
-        required=True,
+        '-d',
+        '--directory',
+        type=directory_type,
+        help='Directory to store the XML file',
+        required=False,
+        default='.'
     )
     args = parser.parse_args()
     interface_whitelist = args.whitelist
-    xml_file = args.file
+    xml_file = '{}/DEFAULT_FASTRTPS_PROFILES.xml'.format(args.directory)
 
-    profiles = {
-        'transport_descriptors': {
-                'transport_descriptor': {
-                    'transport_id': 'apex_transport_descriptor',
-                    'type': 'UDPv4',
-                    'interfaceWhiteList': interface_whitelist,
-                },
-        },
-        'participant': {
-            'rtps': {
-                'name': 'Apex participant profile',
-                'useBuiltinTransports': 'false',
-                'userTransports': {
-                    'transport_id': 'apex_transport_descriptor',
-                },
-            },
-        },
-    }
+    doc = Document()
+    # Top level tag profiles
+    profiles = doc.createElement('profiles')
 
-    xml = parseString(
-        dicttoxml(
-            profiles,
-            item_func=(
-                lambda parent_name: 'address'
-                if parent_name == 'interfaceWhiteList'
-                else parent_name
-            ),
-            custom_root='profiles',
-            attr_type=False,
-        ).decode()
-    )
+    # Transport desciptors
+    transport_descriptors = doc.createElement('transport_descriptors')
 
-    part_el = xml.documentElement.getElementsByTagName('participant').item(0)
-    part_el.setAttribute('profile_name', 'apex_profile')
-    part_el.setAttribute('is_default_profile', 'true')
+    # Transport desciptor
+    transport_descriptor = doc.createElement('transport_descriptor')
+    # Transport desciptor ID
+    transport_id = doc.createElement('transport_id')
+    transport_id.appendChild(doc.createTextNode('apex_transport_descriptor'))
+    transport_descriptor.appendChild(transport_id)
+    # Transport desciptor type
+    transport_type = doc.createElement('type')
+    transport_type.appendChild(doc.createTextNode('UDPv4'))
+    transport_descriptor.appendChild(transport_type)
+    # Transport desciptor whitelist
+    if interface_whitelist:
+        whitelists = doc.createElement('interfaceWhiteList')
+        for element in interface_whitelist:
+            address = doc.createElement('address')
+            address.appendChild(doc.createTextNode(element))
+            whitelists.appendChild(address)
+        transport_descriptor.appendChild(whitelists)
+    # Append transport descriptor to transport_descriptor
+    transport_descriptors.appendChild(transport_descriptor)
+    # Append transport descriptors to profile
+    profiles.appendChild(transport_descriptors)
+
+    # Participant
+    participant = doc.createElement('participant')
+    # Participant attributes
+    participant.setAttribute('profile_name', 'apex_profile')
+    participant.setAttribute('is_default_profile', 'true')
+    # Participant RTPS
+    rtps = doc.createElement('rtps')
+    # Participant RTPS name
+    name = doc.createElement('name')
+    name.appendChild(doc.createTextNode('Apex participant profile'))
+    rtps.appendChild(name)
+    # Participant RTPS useBuiltinTransports flag
+    use_btp = doc.createElement('useBuiltinTransports')
+    use_btp.appendChild(doc.createTextNode('false'))
+    rtps.appendChild(use_btp)
+    # Participant RTPS user transports
+    user_transports = doc.createElement('userTransports')
+    # Participant RTPS user transports ID
+    transport_id = doc.createElement('transport_id')
+    transport_id.appendChild(doc.createTextNode('apex_transport_descriptor'))
+    user_transports.appendChild(transport_id)
+    rtps.appendChild(user_transports)
+
+    # Append RTPS to participant
+    participant.appendChild(rtps)
+    # Append participant to profiles
+    profiles.appendChild(participant)
+    # Append profiles to document
+    doc.appendChild(profiles)
+
+    # Write to file
     with open(xml_file, 'w') as f:
-        f.write(xml.toprettyxml(indent=' '*2).split('\n', 1)[1])
+        # Convert to string with 2-space identation,
+        # not taking the first line of the XML.
+        f.write(doc.toprettyxml(indent=' '*2).split('\n', 1)[1])

--- a/performance_test/src/communication_abstractions/resource_manager.cpp
+++ b/performance_test/src/communication_abstractions/resource_manager.cpp
@@ -50,9 +50,10 @@ eprosima::fastrtps::Participant * ResourceManager::fastrtps_participant() const
   std::lock_guard<std::mutex> lock(m_global_mutex);
 
   eprosima::fastrtps::Participant * result = nullptr;
-
   eprosima::fastrtps::ParticipantAttributes PParam;
 
+  eprosima::fastrtps::xmlparser::XMLProfileManager::loadDefaultXMLFile();
+  eprosima::fastrtps::xmlparser::XMLProfileManager::getDefaultParticipantAttributes(PParam);
   PParam.rtps.sendSocketBufferSize = 1048576;
   PParam.rtps.listenSocketBufferSize = 4194304;
   PParam.rtps.builtin.use_SIMPLE_RTPSParticipantDiscoveryProtocol = true;

--- a/performance_test/src/communication_abstractions/resource_manager.hpp
+++ b/performance_test/src/communication_abstractions/resource_manager.hpp
@@ -20,6 +20,7 @@
 #ifdef PERFORMANCE_TEST_FASTRTPS_ENABLED
   #include <fastrtps/participant/Participant.h>
   #include <fastrtps/attributes/ParticipantAttributes.h>
+  #include <fastrtps/xmlparser/XMLProfileManager.h>
   #include <fastrtps/Domain.h>
 #endif
 


### PR DESCRIPTION
To be able to limit the network interfaces used for the communication during the test runs, an interfaces whitelist is loaded from a XML configuration file with the default name. This file is generated with generate_apex_xml.py, passing a list of ip address and a destination to it. The resulting file needs to be placed on the directory from where the tests are run. If PERFORMANCE_TEST_FASTRTPS_ENABLED is set to true, resource_manage.cpp loads the participant attributes specified in the XML file using eProsima xmlparser to get the whitelist.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/performance_test/69)
<!-- Reviewable:end -->
