### PR TITLE
ROS2 Polling Subscription Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 **Version Support:** ROS2 Dashing, Fast-RTPS 1.8.0
 
 This test allows you to test performance and latency of various communication means
-like ROS 2, FastRTPS, Connext DDS Micro and Eclipse Cyclone DDS.
+like ROS 2, ROS 2 Waitset, FastRTPS, Connext DDS Micro and Eclipse Cyclone DDS.
 
 It can be extended to other communication frameworks easily.
 

--- a/performance_test/CMakeLists.txt
+++ b/performance_test/CMakeLists.txt
@@ -177,6 +177,7 @@ set(sources
     src/communication_abstractions/communicator.cpp
     src/communication_abstractions/resource_manager.cpp
     src/communication_abstractions/resource_manager.hpp
+    src/communication_abstractions/ros2_communicator.hpp
     src/communication_abstractions/ros2_callback_communicator.hpp
     src/experiment_configuration/topics.hpp
     src/data_running/data_runner.hpp
@@ -193,6 +194,17 @@ set(sources
     src/utilities/spin_lock.hpp
     src/utilities/statistics_tracker.hpp
 )
+
+# ROS2 Waitset
+option(PERFORMANCE_TEST_POLLING_SUBSCRIPTION_ENABLED "Option to enable Polling Subscription Plugin.
+  The plugin can only work if ApexOS is present, otherwise it will fail." OFF)
+
+if(PERFORMANCE_TEST_POLLING_SUBSCRIPTION_ENABLED)
+    add_definitions(-DPERFORMANCE_TEST_POLLING_SUBSCRIPTION_ENABLED)
+    set(sources ${sources}
+      src/communication_abstractions/ros2_waitset_communicator.hpp
+    )
+endif()
 
 if(PERFORMANCE_TEST_FASTRTPS_ENABLED)
     set(sources ${sources}

--- a/performance_test/design/performance_test-design.md
+++ b/performance_test/design/performance_test-design.md
@@ -38,6 +38,7 @@ perfplot NAME_OF_LOG_FILE
 * `-DPERFORMANCE_TEST_FASTRTPS_ENABLED` Enables FastRTPS support. Enabled by default.
 * `-DPERFORMANCE_TEST_CYCLONEDDS_ENABLED` Enables CycloneDDS support. Enabled by default.
 * `-DODB_FOR_SQL_ENABLED` Enables saving results to SQL database format. Disabled by default.
+* `-DPERFORMANCE_TEST_POLLING_SUBSCRIPTION_ENABLED` Enables ROS2 Waitset support. Disabled by default.
 
 > ROS 2 support is always enabled.
 
@@ -95,6 +96,3 @@ https://gitlab.apex.ai/ApexAI/grand_central/issues/957
 https://gitlab.apex.ai/ApexAI/grand_central/issues/1305
 https://gitlab.apex.ai/ApexAI/grand_central/issues/1382
 https://gitlab.apex.ai/ApexAI/grand_central/issues/1305
-
-
-

--- a/performance_test/src/communication_abstractions/ros2_callback_communicator.hpp
+++ b/performance_test/src/communication_abstractions/ros2_callback_communicator.hpp
@@ -21,165 +21,44 @@
 #include <atomic>
 
 #include "../experiment_configuration/topics.hpp"
-#include "../experiment_configuration/qos_abstraction.hpp"
 
-#include "communicator.hpp"
+#include "ros2_communicator.hpp"
 #include "resource_manager.hpp"
 
 namespace performance_test
 {
-
-/// Translates abstract QOS settings to specific QOS settings for ROS 2.
-class ROS2QOSAdapter
-{
-public:
-  /**
-   * \brief The constructor which will save the provided abstract QOS.
-   * \param qos The abstract QOS to derive the settings from.
-   */
-  explicit ROS2QOSAdapter(const QOSAbstraction qos)
-  : m_qos(qos)
-  {}
-  /// Gets a ROS 2 QOS profile derived from the stored abstract QOS.
-  inline rmw_qos_profile_t get() const
-  {
-    rmw_qos_profile_t ros_qos;
-    memset(&ros_qos, 0, sizeof(ros_qos));
-
-    if (m_qos.reliability == QOSAbstraction::Reliability::BEST_EFFORT) {
-      ros_qos.reliability = rmw_qos_reliability_policy_t::RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
-    } else if (m_qos.reliability == QOSAbstraction::Reliability::RELIABLE) {
-      ros_qos.reliability = rmw_qos_reliability_policy_t::RMW_QOS_POLICY_RELIABILITY_RELIABLE;
-    } else {
-      throw std::runtime_error("Unsupported QOS!");
-    }
-
-    if (m_qos.durability == QOSAbstraction::Durability::VOLATILE) {
-      ros_qos.durability = rmw_qos_durability_policy_t::RMW_QOS_POLICY_DURABILITY_VOLATILE;
-    } else if (m_qos.durability == QOSAbstraction::Durability::TRANSIENT_LOCAL) {
-      ros_qos.durability = rmw_qos_durability_policy_t::RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
-    } else {
-      throw std::runtime_error("Unsupported QOS!");
-    }
-
-
-    if (m_qos.history_kind == QOSAbstraction::HistoryKind::KEEP_ALL) {
-      ros_qos.history = rmw_qos_history_policy_t::RMW_QOS_POLICY_HISTORY_KEEP_ALL;
-    } else if (m_qos.history_kind == QOSAbstraction::HistoryKind::KEEP_LAST) {
-      ros_qos.history = rmw_qos_history_policy_t::RMW_QOS_POLICY_HISTORY_KEEP_LAST;
-    } else {
-      throw std::runtime_error("Unsupported QOS!");
-    }
-    ros_qos.depth = m_qos.history_depth;
-
-    return ros_qos;
-  }
-
-private:
-  const QOSAbstraction m_qos;
-};
-
 /// Communication plugin for ROS 2 using ROS 2 callbacks for the subscription side.
 template<class Topic>
-class ROS2CallbackCommunicator : public Communicator
+class ROS2CallbackCommunicator : public ROS2Communicator<Topic>
 {
 public:
   /// The data type to publish and subscribe to.
-  using DataType = typename Topic::RosType;
+  using DataType = typename ROS2Communicator<Topic>::DataType;
 
   /// Constructor which takes a reference \param lock to the lock to use.
   explicit ROS2CallbackCommunicator(SpinLock & lock)
-  : Communicator(lock),
-    m_node(ResourceManager::get().ros2_node()),
-    m_publisher(nullptr),
+  : ROS2Communicator<Topic>(lock),
     m_subscription(nullptr)
   {
-    m_executor.add_node(m_node);
-  }
-
-  /**
-   * \brief Publishes the provided data.
-   *
-   *  The first time this function is called it also creates the publisher.
-   *  Further it updates all internal counters while running.
-   *
-   * \param data The data to publish.
-   * \param time The time to fill into the data field.
-   */
-  void publish(DataType & data, const std::chrono::nanoseconds time)
-  {
-    if (!m_publisher) {
-      auto qos = ROS2QOSAdapter(m_ec.qos()).get();
-      // Workaround for bug where RMW/FastRPS keeps history of volatile publisher.
-      if (qos.durability == rmw_qos_durability_policy_t::RMW_QOS_POLICY_DURABILITY_VOLATILE) {
-        qos.history = rmw_qos_history_policy_t::RMW_QOS_POLICY_HISTORY_KEEP_LAST;
-        qos.depth = std::size_t(10);  // Setting depth to 10 as a safety net.
-      }
-      // End of workaround.
-
-      m_publisher = m_node->create_publisher<DataType>(
-        Topic::topic_name() + m_ec.pub_topic_postfix(), qos);
-    }
-    lock();
-    data.time = time.count();
-    data.id = next_sample_id();
-    increment_sent();  // We increment before publishing so we don't have to lock twice.
-    unlock();
-    m_publisher->publish(data);
+    m_executor.add_node(this->m_node);
   }
 
   /// Reads received data from ROS 2 using callbacks
-  void update_subscription()
+  void update_subscription() override
   {
     if (!m_subscription) {
-      const auto qos = ROS2QOSAdapter(m_ec.qos()).get();
-      m_subscription = m_node->create_subscription<DataType>(
-        Topic::topic_name() + m_ec.sub_topic_postfix(),
-        std::bind(&ROS2CallbackCommunicator::callback, this, std::placeholders::_1), qos);
+      m_subscription = this->m_node->template create_subscription<DataType>(
+        Topic::topic_name() + this->m_ec.sub_topic_postfix(), this->m_ROS2QOSAdapter,
+        [this](const typename DataType::SharedPtr data) {this->callback(data);});
     }
-    lock();
+    this->lock();
     m_executor.spin_once(std::chrono::milliseconds(100));
-    unlock();
-  }
-  /// Returns the accumulated data size in bytes.
-  std::size_t data_received()
-  {
-    return num_received_samples() * sizeof(DataType);
+    this->unlock();
   }
 
 private:
-  /**
-   * \brief Callback handler which handles the received data.
-   *
-   * * Verifies that the data arrived in the right order, chronologically and also consistent with the publishing order.
-   * * Counts recieved and lost samples.
-   * * Calculates the latency of the samples received and updates the statistics accordingly.
-   *
-   * \param data The data received.
-   */
-  void callback(const typename DataType::SharedPtr data)
-  {
-    if (m_prev_timestamp >= data->time) {
-      throw std::runtime_error(
-              "Data consistency violated. Received sample with not strictly older timestamp");
-    }
-
-    if (m_ec.roundtrip_mode() == ExperimentConfiguration::RoundTripMode::RELAY) {
-      unlock();
-      publish(*data, std::chrono::nanoseconds(data->time));
-      lock();
-    } else {
-      m_prev_timestamp = data->time;
-      update_lost_samples_counter(data->id);
-      add_latency_to_statistics(data->time);
-    }
-    increment_received();
-  }
-
-  std::shared_ptr<rclcpp::Node> m_node;
   rclcpp::executors::SingleThreadedExecutor m_executor;
-  std::shared_ptr<::rclcpp::Publisher<DataType, std::allocator<void>>> m_publisher;
-  std::shared_ptr<::rclcpp::Subscription<DataType, std::allocator<void>>> m_subscription;
+  std::shared_ptr<::rclcpp::Subscription<DataType>> m_subscription;
 };
 
 

--- a/performance_test/src/communication_abstractions/ros2_communicator.hpp
+++ b/performance_test/src/communication_abstractions/ros2_communicator.hpp
@@ -1,0 +1,196 @@
+// Copyright 2017 Apex.AI, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COMMUNICATION_ABSTRACTIONS__ROS2_COMMUNICATOR_HPP_
+#define COMMUNICATION_ABSTRACTIONS__ROS2_COMMUNICATOR_HPP_
+
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <memory>
+#include <atomic>
+
+#include "../experiment_configuration/topics.hpp"
+#include "../experiment_configuration/qos_abstraction.hpp"
+
+#include "communicator.hpp"
+#include "resource_manager.hpp"
+
+namespace performance_test
+{
+
+/// Translates abstract QOS settings to specific QOS settings for ROS 2.
+class ROS2QOSAdapter
+{
+public:
+  /**
+   * \brief The constructor which will save the provided abstract QOS.
+   * \param qos The abstract QOS to derive the settings from.
+   */
+  explicit ROS2QOSAdapter(const QOSAbstraction qos)
+  : m_qos(qos) {}
+  /// Gets a ROS 2 QOS profile derived from the stored abstract QOS.
+  inline rclcpp::QoS get() const
+  {
+    rclcpp::QoS ros_qos(m_qos.history_depth);
+
+    if (m_qos.reliability == QOSAbstraction::Reliability::BEST_EFFORT) {
+      ros_qos.best_effort();
+    } else if (m_qos.reliability == QOSAbstraction::Reliability::RELIABLE) {
+      ros_qos.reliable();
+    } else {
+      throw std::runtime_error("Unsupported QOS!");
+    }
+
+    if (m_qos.durability == QOSAbstraction::Durability::VOLATILE) {
+      ros_qos.durability_volatile();
+    } else if (m_qos.durability == QOSAbstraction::Durability::TRANSIENT_LOCAL) {
+      ros_qos.transient_local();
+    } else {
+      throw std::runtime_error("Unsupported QOS!");
+    }
+
+    if (m_qos.history_kind == QOSAbstraction::HistoryKind::KEEP_ALL) {
+      ros_qos.keep_all();
+    } else if (m_qos.history_kind == QOSAbstraction::HistoryKind::KEEP_LAST) {
+      ros_qos.keep_last(m_qos.history_depth);
+    } else {
+      throw std::runtime_error("Unsupported QOS!");
+    }
+
+    return ros_qos;
+  }
+
+private:
+  const QOSAbstraction m_qos;
+};
+
+/// Communication plugin interface for ROS 2 for the subscription side.
+template<class Topic>
+class ROS2Communicator : public Communicator
+{
+public:
+  /// The data type to publish and subscribe to.
+  using DataType = typename Topic::RosType;
+
+  /// Constructor which takes a reference \param lock to the lock to use.
+  explicit ROS2Communicator(SpinLock & lock)
+  : Communicator(lock),
+    m_node(ResourceManager::get().ros2_node()),
+    m_ROS2QOSAdapter(ROS2QOSAdapter(m_ec.qos()).get()) {}
+
+  /**
+   * \brief Publishes the provided data.
+   *
+   *  The first time this function is called it also creates the publisher.
+   *  Further it updates all internal counters while running.
+   *
+   * \param data The data to publish.
+   * \param time The time to fill into the data field.
+   */
+  void publish(DataType & data, const std::chrono::nanoseconds time)
+  {
+    if (!m_publisher) {
+      auto ros2QOSAdapter = m_ROS2QOSAdapter;
+      // Workaround for bug where RMW/FastRPS keeps history of volatile publisher.
+      if (ros2QOSAdapter.get_rmw_qos_profile().durability ==
+        rmw_qos_durability_policy_t::RMW_QOS_POLICY_DURABILITY_VOLATILE)
+      {
+        ros2QOSAdapter.keep_last(std::size_t(10));  // Setting depth to 10 as a safety net.
+      }
+      // End of workaround.
+
+      m_publisher = m_node->create_publisher<DataType>(
+        Topic::topic_name() + m_ec.pub_topic_postfix(), ros2QOSAdapter);
+    }
+    lock();
+    data.time = time.count();
+    data.id = next_sample_id();
+    increment_sent();  // We increment before publishing so we don't have to lock twice.
+    unlock();
+    m_publisher->publish(data);
+  }
+
+  /**
+ * \brief Publishes the provided data.
+ *
+ *  This is an overloaded version of the publish function .
+ *  We need this because this is triggered by ROS2 executor thread callback
+ *  when the ExperimentConfiguration RoundTripMode is RELAY and the callback passes a
+ *  const ref for the incoming data. We have to create a copy of the data to be able to
+ *  update it inside the function before publishing.
+ *
+ * \param data The data to publish.
+ * \param time The time to fill into the data field.
+ */
+  void publish(const DataType & data, const std::chrono::nanoseconds time)
+  {
+    DataType copy = data;
+    publish(copy, time);
+  }
+
+  /// Reads received data from ROS 2 using callbacks
+  virtual void update_subscription() = 0;
+
+  /// Returns the accumulated data size in bytes.
+  std::size_t data_received()
+  {
+    return num_received_samples() * sizeof(DataType);
+  }
+
+protected:
+  std::shared_ptr<rclcpp::Node> m_node;
+  rclcpp::QoS m_ROS2QOSAdapter;
+  /**
+   * \brief Callback handler which handles the received data.
+   *
+   * * Verifies that the data arrived in the right order, chronologically and also consistent with the publishing order.
+   * * Counts recieved and lost samples.
+   * * Calculates the latency of the samples received and updates the statistics accordingly.
+   *
+   * \param data The data received.
+   */
+  void callback(const typename DataType::SharedPtr data)
+  {
+    callback(*data);
+  }
+
+  template<class T>
+  void callback(T & data)
+  {
+    static_assert(std::is_same<DataType,
+      typename std::remove_cv<typename std::remove_reference<T>::type>::type>::value,
+      "Parameter type passed to callback() does not match");
+    if (m_prev_timestamp >= data.time) {
+      throw std::runtime_error(
+              "Data consistency violated. Received sample with not strictly older timestamp");
+    }
+
+    if (m_ec.roundtrip_mode() == ExperimentConfiguration::RoundTripMode::RELAY) {
+      unlock();
+      publish(data, std::chrono::nanoseconds(data.time));
+      lock();
+    } else {
+      m_prev_timestamp = data.time;
+      update_lost_samples_counter(data.id);
+      add_latency_to_statistics(data.time);
+    }
+    increment_received();
+  }
+
+private:
+  std::shared_ptr<::rclcpp::Publisher<DataType>> m_publisher;
+};
+}  // namespace performance_test
+#endif  // COMMUNICATION_ABSTRACTIONS__ROS2_COMMUNICATOR_HPP_

--- a/performance_test/src/communication_abstractions/ros2_waitset_communicator.hpp
+++ b/performance_test/src/communication_abstractions/ros2_waitset_communicator.hpp
@@ -1,0 +1,75 @@
+// Copyright 2017 Apex.AI, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COMMUNICATION_ABSTRACTIONS__ROS2_WAITSET_COMMUNICATOR_HPP_
+#define COMMUNICATION_ABSTRACTIONS__ROS2_WAITSET_COMMUNICATOR_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <memory>
+#include <atomic>
+
+#include "../experiment_configuration/topics.hpp"
+#include "../experiment_configuration/qos_abstraction.hpp"
+
+#include "ros2_communicator.hpp"
+#include "resource_manager.hpp"
+
+namespace performance_test
+{
+
+/// Communication plugin for ROS 2 using waitsets for the subscription side.
+template<class Topic>
+class ROS2WaitsetCommunicator : public ROS2Communicator<Topic>
+{
+public:
+  /// The data type to publish and subscribe to.
+  using DataType = typename ROS2Communicator<Topic>::DataType;
+
+  /// Constructor which takes a reference \param lock to the lock to use.
+  explicit ROS2WaitsetCommunicator(SpinLock & lock)
+  : ROS2Communicator<Topic>(lock),
+    m_polling_subscription(nullptr) {}
+
+  /// Reads received data from ROS 2 using waitsets
+  void update_subscription() override
+  {
+    if (!m_polling_subscription) {
+      m_polling_subscription = this->m_node->template create_polling_subscription<DataType>(
+        Topic::topic_name() + this->m_ec.sub_topic_postfix(), this->m_ROS2QOSAdapter);
+      m_waitset = std::make_unique<rclcpp::Waitset<>>(m_polling_subscription);
+    }
+    try {
+      const auto wait_ret = m_waitset->wait(std::chrono::milliseconds(100));
+      this->lock();
+      if (wait_ret.any()) {
+        auto received_sample = m_polling_subscription->take();
+        if (received_sample) {
+          this->template callback(received_sample.data());
+        }
+      }
+    } catch (const rclcpp::TimeoutError &) {
+      std::cerr << "Waitset timed out without receiving a sample." << std::endl;
+    }
+    this->unlock();
+  }
+
+private:
+  std::shared_ptr<::rclcpp::PollingSubscription<DataType>> m_polling_subscription;
+  std::unique_ptr<rclcpp::Waitset<>> m_waitset;
+};
+
+}  // namespace performance_test
+
+#endif  // COMMUNICATION_ABSTRACTIONS__ROS2_WAITSET_COMMUNICATOR_HPP_

--- a/performance_test/src/data_running/data_runner_factory.cpp
+++ b/performance_test/src/data_running/data_runner_factory.cpp
@@ -21,6 +21,10 @@
 
 #include "../communication_abstractions/ros2_callback_communicator.hpp"
 
+#ifdef PERFORMANCE_TEST_POLLING_SUBSCRIPTION_ENABLED
+  #include "../communication_abstractions/ros2_waitset_communicator.hpp"
+#endif
+
 #ifdef PERFORMANCE_TEST_FASTRTPS_ENABLED
   #include "../communication_abstractions/fast_rtps_communicator.hpp"
 #endif
@@ -54,6 +58,10 @@ std::shared_ptr<DataRunnerBase> DataRunnerFactory::get(
         }
         if (com_mean == CommunicationMean::ROS2) {
           ptr = std::make_shared<DataRunner<ROS2CallbackCommunicator<T>>>(run_type);
+#ifdef PERFORMANCE_TEST_POLLING_SUBSCRIPTION_ENABLED
+        } else if (com_mean == CommunicationMean::ROS2PollingSubscription) {
+          ptr = std::make_shared<DataRunner<ROS2WaitsetCommunicator<T>>>(run_type);
+#endif
 #ifdef PERFORMANCE_TEST_FASTRTPS_ENABLED
         } else if (com_mean == CommunicationMean::FASTRTPS) {
           ptr = std::make_shared<DataRunner<FastRTPSCommunicator<T>>>(run_type);

--- a/performance_test/src/experiment_configuration/communication_mean.hpp
+++ b/performance_test/src/experiment_configuration/communication_mean.hpp
@@ -24,6 +24,9 @@ namespace performance_test
 enum class CommunicationMean
 {
   ROS2
+#ifdef PERFORMANCE_TEST_POLLING_SUBSCRIPTION_ENABLED
+  , ROS2PollingSubscription
+#endif
 #ifdef PERFORMANCE_TEST_FASTRTPS_ENABLED
   , FASTRTPS
 #endif
@@ -40,6 +43,10 @@ inline std::ostream & operator<<(std::ostream & stream, const CommunicationMean 
 {
   if (cm == CommunicationMean::ROS2) {
     return stream << "ROS2";
+#ifdef PERFORMANCE_TEST_POLLING_SUBSCRIPTION_ENABLED
+  } else if (cm == CommunicationMean::ROS2PollingSubscription) {
+    return stream << "ROS2PollingSubscription";
+#endif
 #ifdef PERFORMANCE_TEST_FASTRTPS_ENABLED
   } else if (cm == CommunicationMean::FASTRTPS) {
     return stream << "FASTRTPS";

--- a/performance_test/src/experiment_configuration/experiment_configuration.cpp
+++ b/performance_test/src/experiment_configuration/experiment_configuration.cpp
@@ -74,7 +74,9 @@ void ExperimentConfiguration::setup(int argc, char ** argv)
     "Optionally specify a logfile.")("rate,r", po::value<uint32_t>()->default_value(1000),
     "The rate data should be published. Defaults to 1000 Hz. 0 means publish as fast as possible.")(
     "communication,c", po::value<std::string>()->required(),
-    "Communication plugin to use (ROS2, FastRTPS, ConnextDDSMicro, CycloneDDS)")("topic,t",
+    "Communication plugin to use (ROS2, FastRTPS, ConnextDDSMicro, CycloneDDS, "
+    "ROS2PollingSubscription)")(
+    "topic,t",
     po::value<std::string>()->required(),
     "Topic to use. Use --topic_list to get a list.")("topic_list",
     "Prints list of available topics and exits.")("dds_domain_id",
@@ -152,6 +154,14 @@ void ExperimentConfiguration::setup(int argc, char ** argv)
 
     if (vm["communication"].as<std::string>() == "ROS2") {
       m_com_mean = CommunicationMean::ROS2;
+    } else if (vm["communication"].as<std::string>() == "ROS2PollingSubscription") {
+#ifdef PERFORMANCE_TEST_POLLING_SUBSCRIPTION_ENABLED
+      m_com_mean = CommunicationMean::ROS2PollingSubscription;
+#else
+      throw std::invalid_argument(
+              "You must compile with PERFORMANCE_TEST_POLLING_SUBSCRIPTION_ENABLED flag as ON to "
+              "enable it as communication mean.");
+#endif
     } else if (vm["communication"].as<std::string>() == "FastRTPS") {
 #ifdef PERFORMANCE_TEST_FASTRTPS_ENABLED
       m_com_mean = CommunicationMean::FASTRTPS;


### PR DESCRIPTION
Added polling subscription plugin for ROS 2 to the performance test. It can be used by specifying the argument `-c [ --communication ]` arg  Communication plugin to use as `ROS2PollingSub` when running performance test . 

To turn on the option for using Polling Subscription Plugin we need to compile the performance test with cmake args `PERFORMANCE_TEST_POLLING_SUBSCRIPTION_ENABLED` and value as `ON`  :

```bash
colcon build --cmake-clean-cache --cmake-args -DPERFORMANCE_TEST_POLLING_SUBSCRIPTION_ENABLED=ON
```
Sample usage for the plugin can be :
```bash
ros2 run performance_test perf_test -c ROS2PollingSubscription -l log -t Array16k --history_depth 100 --max_runtime 60 -p 1 -s 1 -r 20 --reliable --keep_last`
```
I have verified that this plugin builds and runs successfully on ApexOS version : `0d34c574917d`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/performance_test/88)
<!-- Reviewable:end -->
