### PR TITLE
Use ROS2 QoS new class and update classes accordingly

### DIFF
--- a/performance_test/CMakeLists.txt
+++ b/performance_test/CMakeLists.txt
@@ -82,6 +82,7 @@ if(${rclcpp_VERSION_MINOR} STRGREATER "7")
   add_definitions(-DROS_ELOQUENT)
 else()
   message(STATUS "Ros Dashing detected")
+  add_definitions(-DUSE_LEGACY_QOS_API)
 endif()
 
 ament_export_include_directories(include)

--- a/performance_test/CMakeLists.txt
+++ b/performance_test/CMakeLists.txt
@@ -38,11 +38,10 @@ endif()
 # Use ODB support to create SQL database
 option(PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED "Enable ODB for SQL" OFF)
 
-# Build code using ROS Eloquent packages
-option(ROS_ELOQUENT_ENABLED "Use ROS Eloquent" OFF)
-
-if(ROS_ELOQUENT_ENABLED)
-  add_definitions(-DROS_ELOQUENT)
+if(DEFINED ENV{ROS_DISTRO})
+  if ($ENV{ROS_DISTRO} STREQUAL "eloquent")
+    add_definitions(-DROS_ELOQUENT)
+  endif()
 endif()
 
 if(PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED)

--- a/performance_test/CMakeLists.txt
+++ b/performance_test/CMakeLists.txt
@@ -38,12 +38,6 @@ endif()
 # Use ODB support to create SQL database
 option(PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED "Enable ODB for SQL" OFF)
 
-if(DEFINED ENV{ROS_DISTRO})
-  if ($ENV{ROS_DISTRO} STREQUAL "eloquent")
-    add_definitions(-DROS_ELOQUENT)
-  endif()
-endif()
-
 if(PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED)
   add_definitions(-DPERFORMANCE_TEST_ODB_FOR_SQL_ENABLED)
   option(PERFORMANCE_TEST_ODB_SQLITE "Select DB type" ON)
@@ -80,6 +74,14 @@ if(${osrf_testing_tools_cpp_FOUND})
     list(APPEND OPTIONAL_AMENT_DEPENDENCES "osrf_testing_tools_cpp")
     list(APPEND OPTIONAL_LIBRARIES osrf_testing_tools_cpp::memory_tools)
     add_definitions(-DPERFORMANCE_TEST_MEMORYTOOLS_ENABLED)
+endif()
+
+# Dashing version looks like 0.7.X.
+if(${rclcpp_VERSION_MINOR} STRGREATER "7")
+  message(STATUS "Ros Eloquent detected")
+  add_definitions(-DROS_ELOQUENT)
+else()
+  message(STATUS "Ros Dashing detected")
 endif()
 
 ament_export_include_directories(include)

--- a/performance_test/CMakeLists.txt
+++ b/performance_test/CMakeLists.txt
@@ -38,6 +38,13 @@ endif()
 # Use ODB support to create SQL database
 option(PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED "Enable ODB for SQL" OFF)
 
+# Build code using ROS Eloquent packages
+option(ROS_ELOQUENT_ENABLED "Use ROS Eloquent" OFF)
+
+if(ROS_ELOQUENT_ENABLED)
+  add_definitions(-DROS_ELOQUENT)
+endif()
+
 if(PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED)
   add_definitions(-DPERFORMANCE_TEST_ODB_FOR_SQL_ENABLED)
   option(PERFORMANCE_TEST_ODB_SQLITE "Select DB type" ON)

--- a/performance_test/helper_scripts/run_experiment.py
+++ b/performance_test/helper_scripts/run_experiment.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Script to run a batch of performance experiments."""
+
 from enum import Enum
 import itertools
 import os

--- a/performance_test/src/communication_abstractions/resource_manager.cpp
+++ b/performance_test/src/communication_abstractions/resource_manager.cpp
@@ -60,12 +60,12 @@ eprosima::fastrtps::Participant * ResourceManager::fastrtps_participant() const
   eprosima::fastrtps::xmlparser::XMLProfileManager::getDefaultParticipantAttributes(PParam);
   PParam.rtps.sendSocketBufferSize = 1048576;
   PParam.rtps.listenSocketBufferSize = 4194304;
-  PParam.rtps.builtin.use_SIMPLE_RTPSParticipantDiscoveryProtocol = true;
-  PParam.rtps.builtin.use_SIMPLE_EndpointDiscoveryProtocol = true;
-  PParam.rtps.builtin.m_simpleEDP.use_PublicationReaderANDSubscriptionWriter = true;
-  PParam.rtps.builtin.m_simpleEDP.use_PublicationWriterANDSubscriptionReader = true;
+  eprosima::fastrtps::rtps::DiscoverySettings & disc_config = PParam.rtps.builtin.discovery_config;
+  disc_config.use_SIMPLE_EndpointDiscoveryProtocol = true;
+  disc_config.m_simpleEDP.use_PublicationReaderANDSubscriptionWriter = true;
+  disc_config.m_simpleEDP.use_PublicationWriterANDSubscriptionReader = true;
+  disc_config.leaseDuration = eprosima::fastrtps::c_TimeInfinite;
   PParam.rtps.builtin.domainId = m_ec.dds_domain_id();
-  PParam.rtps.builtin.leaseDuration = eprosima::fastrtps::c_TimeInfinite;
   PParam.rtps.setName("performance_test_fastRTPS");
 
   if (!m_ec.use_single_participant()) {

--- a/performance_test/src/communication_abstractions/resource_manager.cpp
+++ b/performance_test/src/communication_abstractions/resource_manager.cpp
@@ -14,6 +14,11 @@
 
 #include "resource_manager.hpp"
 
+#ifdef PERFORMANCE_TEST_FASTRTPS_ENABLED
+  #include <fastrtps/rtps/attributes/RTPSParticipantAttributes.h>
+#endif
+
+
 #include <memory>
 #include <string>
 

--- a/performance_test/src/communication_abstractions/resource_manager.cpp
+++ b/performance_test/src/communication_abstractions/resource_manager.cpp
@@ -14,7 +14,7 @@
 
 #include "resource_manager.hpp"
 
-#if defined(PERFORMANCE_TEST_FASTRTPS_ENABLED) && defined(ROS_ELOQUENT)
+#if defined(PERFORMANCE_TEST_FASTRTPS_ENABLED) && !defined(USE_LEGACY_QOS_API)
   #include <fastrtps/rtps/attributes/RTPSParticipantAttributes.h>
 #endif
 
@@ -65,18 +65,18 @@ eprosima::fastrtps::Participant * ResourceManager::fastrtps_participant() const
   eprosima::fastrtps::xmlparser::XMLProfileManager::getDefaultParticipantAttributes(PParam);
   PParam.rtps.sendSocketBufferSize = 1048576;
   PParam.rtps.listenSocketBufferSize = 4194304;
-#ifdef ROS_ELOQUENT
-  eprosima::fastrtps::rtps::DiscoverySettings & disc_config = PParam.rtps.builtin.discovery_config;
-  disc_config.use_SIMPLE_EndpointDiscoveryProtocol = true;
-  disc_config.m_simpleEDP.use_PublicationReaderANDSubscriptionWriter = true;
-  disc_config.m_simpleEDP.use_PublicationWriterANDSubscriptionReader = true;
-  disc_config.leaseDuration = eprosima::fastrtps::c_TimeInfinite;
-#else
+#ifdef USE_LEGACY_QOS_API
   PParam.rtps.builtin.use_SIMPLE_RTPSParticipantDiscoveryProtocol = true;
   PParam.rtps.builtin.use_SIMPLE_EndpointDiscoveryProtocol = true;
   PParam.rtps.builtin.m_simpleEDP.use_PublicationReaderANDSubscriptionWriter = true;
   PParam.rtps.builtin.m_simpleEDP.use_PublicationWriterANDSubscriptionReader = true;
   PParam.rtps.builtin.leaseDuration = eprosima::fastrtps::c_TimeInfinite;
+ #else
+  eprosima::fastrtps::rtps::DiscoverySettings & disc_config = PParam.rtps.builtin.discovery_config;
+  disc_config.use_SIMPLE_EndpointDiscoveryProtocol = true;
+  disc_config.m_simpleEDP.use_PublicationReaderANDSubscriptionWriter = true;
+  disc_config.m_simpleEDP.use_PublicationWriterANDSubscriptionReader = true;
+  disc_config.leaseDuration = eprosima::fastrtps::c_TimeInfinite;
 #endif
   PParam.rtps.builtin.domainId = m_ec.dds_domain_id();
   PParam.rtps.setName("performance_test_fastRTPS");

--- a/performance_test/src/communication_abstractions/resource_manager.cpp
+++ b/performance_test/src/communication_abstractions/resource_manager.cpp
@@ -14,7 +14,7 @@
 
 #include "resource_manager.hpp"
 
-#ifdef PERFORMANCE_TEST_FASTRTPS_ENABLED
+#if defined(PERFORMANCE_TEST_FASTRTPS_ENABLED) && defined(ROS_ELOQUENT)
   #include <fastrtps/rtps/attributes/RTPSParticipantAttributes.h>
 #endif
 
@@ -65,11 +65,19 @@ eprosima::fastrtps::Participant * ResourceManager::fastrtps_participant() const
   eprosima::fastrtps::xmlparser::XMLProfileManager::getDefaultParticipantAttributes(PParam);
   PParam.rtps.sendSocketBufferSize = 1048576;
   PParam.rtps.listenSocketBufferSize = 4194304;
+#ifdef ROS_ELOQUENT
   eprosima::fastrtps::rtps::DiscoverySettings & disc_config = PParam.rtps.builtin.discovery_config;
   disc_config.use_SIMPLE_EndpointDiscoveryProtocol = true;
   disc_config.m_simpleEDP.use_PublicationReaderANDSubscriptionWriter = true;
   disc_config.m_simpleEDP.use_PublicationWriterANDSubscriptionReader = true;
   disc_config.leaseDuration = eprosima::fastrtps::c_TimeInfinite;
+#else
+  PParam.rtps.builtin.use_SIMPLE_RTPSParticipantDiscoveryProtocol = true;
+  PParam.rtps.builtin.use_SIMPLE_EndpointDiscoveryProtocol = true;
+  PParam.rtps.builtin.m_simpleEDP.use_PublicationReaderANDSubscriptionWriter = true;
+  PParam.rtps.builtin.m_simpleEDP.use_PublicationWriterANDSubscriptionReader = true;
+  PParam.rtps.builtin.leaseDuration = eprosima::fastrtps::c_TimeInfinite;
+#endif
   PParam.rtps.builtin.domainId = m_ec.dds_domain_id();
   PParam.rtps.setName("performance_test_fastRTPS");
 

--- a/performance_test/src/communication_abstractions/ros2_callback_communicator.hpp
+++ b/performance_test/src/communication_abstractions/ros2_callback_communicator.hpp
@@ -16,7 +16,6 @@
 #define COMMUNICATION_ABSTRACTIONS__ROS2_CALLBACK_COMMUNICATOR_HPP_
 
 #include <rclcpp/rclcpp.hpp>
-#include <rclcpp/qos.hpp>
 
 #include <memory>
 #include <atomic>

--- a/performance_test/src/communication_abstractions/ros2_callback_communicator.hpp
+++ b/performance_test/src/communication_abstractions/ros2_callback_communicator.hpp
@@ -16,6 +16,7 @@
 #define COMMUNICATION_ABSTRACTIONS__ROS2_CALLBACK_COMMUNICATOR_HPP_
 
 #include <rclcpp/rclcpp.hpp>
+#include <rclcpp/qos.hpp>
 
 #include <memory>
 #include <atomic>

--- a/performance_test/src/experiment_configuration/experiment_configuration.cpp
+++ b/performance_test/src/experiment_configuration/experiment_configuration.cpp
@@ -127,7 +127,13 @@ void ExperimentConfiguration::setup(int argc, char ** argv)
 #endif
   ;
   po::variables_map vm;
+#ifdef ROS_ELOQUENT
+  // ROS eloquent adds by default --ros-args to ros2 launch and no value for that argument
+  // is valid, so we allow unregistered options so boost doesn't complain about it.
   po::store(po::command_line_parser(argc, argv).options(desc).allow_unregistered().run(), vm);
+#else
+  po::store(parse_command_line(argc, argv, desc), vm);
+#endif
   m_perf_test_version = version;
 
   try {

--- a/performance_test/src/experiment_configuration/experiment_configuration.cpp
+++ b/performance_test/src/experiment_configuration/experiment_configuration.cpp
@@ -127,7 +127,7 @@ void ExperimentConfiguration::setup(int argc, char ** argv)
 #endif
   ;
   po::variables_map vm;
-  po::store(parse_command_line(argc, argv, desc), vm);
+  po::store(po::command_line_parser(argc, argv).options(desc).allow_unregistered().run(), vm);
   m_perf_test_version = version;
 
   try {

--- a/performance_test/src/experiment_configuration/experiment_configuration.cpp
+++ b/performance_test/src/experiment_configuration/experiment_configuration.cpp
@@ -127,12 +127,12 @@ void ExperimentConfiguration::setup(int argc, char ** argv)
 #endif
   ;
   po::variables_map vm;
-#ifdef ROS_ELOQUENT
+#if defined(USE_LEGACY_QOS_API)
+  po::store(parse_command_line(argc, argv, desc), vm);
+#else
   // ROS eloquent adds by default --ros-args to ros2 launch and no value for that argument
   // is valid, so we allow unregistered options so boost doesn't complain about it.
   po::store(po::command_line_parser(argc, argv).options(desc).allow_unregistered().run(), vm);
-#else
-  po::store(parse_command_line(argc, argv, desc), vm);
 #endif
   m_perf_test_version = version;
 


### PR DESCRIPTION
Performance test wasn't working for the latest changes in ROS2 repository (**eloquent**), so I updated the necessary files to make it work. Played with some functionality and it seems okay, but I would like to know if there's something I'm missing, since for example `PParam.rtps.builtin.use_SIMPLE_RTPSParticipantDiscoveryProtocol` no longer exists in the RTPS class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/performance_test/89)
<!-- Reviewable:end -->
