### PR TITLE
Support multiple participants for cyclone

### DIFF
--- a/performance_test/src/communication_abstractions/cyclonedds_communicator.hpp
+++ b/performance_test/src/communication_abstractions/cyclonedds_communicator.hpp
@@ -199,15 +199,20 @@ public:
   }
 
 private:
-  /// Registers a topic to the participant. It makes sure that each topic is only registered once.
+  /// Registers a topic to the participant. It makes sure that each topic is only registered
+  /// once if resource manager is using a single participant.
   void register_topic()
   {
-    if (m_topic == 0) {
+    const bool is_single_participant = ResourceManager::get().is_using_single_participant();
+    if (m_single_participant_topic == 0 || !is_single_participant) {
       m_topic = dds_create_topic(m_participant, Topic::CycloneDDSDesc(),
           Topic::topic_name().c_str(), nullptr, nullptr);
+      m_single_participant_topic = m_topic;
       if (m_topic < 0) {
         throw std::runtime_error("failed to create topic");
       }
+    } else {
+      m_topic = m_single_participant_topic;
     }
   }
 
@@ -219,11 +224,12 @@ private:
   dds_entity_t m_waitset;
   dds_entity_t m_condition;
 
-  static dds_entity_t m_topic;
+  dds_entity_t m_topic;
+  static dds_entity_t m_single_participant_topic;
 };
 
 template<class Topic>
-dds_entity_t CycloneDDSCommunicator<Topic>::m_topic = 0;
+dds_entity_t CycloneDDSCommunicator<Topic>::m_single_participant_topic = 0;
 
 }  // namespace performance_test
 

--- a/performance_test/src/communication_abstractions/resource_manager.cpp
+++ b/performance_test/src/communication_abstractions/resource_manager.cpp
@@ -48,6 +48,11 @@ std::shared_ptr<rclcpp::Node> ResourceManager::ros2_node() const
   return rclcpp::Node::make_shared("performance_test" + rand_str, options);
 }
 
+bool ResourceManager::is_using_single_participant() const
+{
+  return m_ec.use_single_participant();
+}
+
 #ifdef PERFORMANCE_TEST_FASTRTPS_ENABLED
 eprosima::fastrtps::Participant * ResourceManager::fastrtps_participant() const
 {

--- a/performance_test/src/communication_abstractions/resource_manager.hpp
+++ b/performance_test/src/communication_abstractions/resource_manager.hpp
@@ -62,6 +62,9 @@ public:
   /// Returns the ROS 2 node.
   std::shared_ptr<rclcpp::Node> ros2_node() const;
 
+  /// Returns true if a single participant is used.
+  bool is_using_single_participant() const;
+
 #ifdef PERFORMANCE_TEST_FASTRTPS_ENABLED
   /// Returns FastRTPS participant.
   eprosima::fastrtps::Participant * fastrtps_participant() const;


### PR DESCRIPTION
As the title says, when a `CycloneDDSCommunicator` is instantiated it tries to create a topic if it doesn't exist yet. But the topic is bound to the participant, so if multiple participants are allowed, then the global topic can't be used for different participants.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/performance_test/90)
<!-- Reviewable:end -->
