### PR TITLE
Add skip start and end iterations parameter for experiments

### DIFF
--- a/performance_test/src/experiment_configuration/experiment_configuration.hpp
+++ b/performance_test/src/experiment_configuration/experiment_configuration.hpp
@@ -89,6 +89,12 @@ public:
   /// \returns Returns the time the application should run until it terminates [s]. This will
   /// throw if the experiment configuration is not set up.
   uint64_t max_runtime() const;
+  /// \returns Returns the amount of iterations that will not be analyzed from the start.
+  /// This will throw if the experiment configuration is not set up.
+  uint64_t skip_start_iterations() const;
+  /// \returns Returns the amount of iterations that will not be analyzed from the end.
+  /// This will throw if the experiment configuration is not set up.
+  uint64_t skip_end_iterations() const;
   /// \returns Returns the configured number of publishers. This will throw if the experiment
   /// configuration is not set up.
   uint32_t number_of_publishers() const;
@@ -139,6 +145,8 @@ private:
     m_dds_domain_id(),
     m_rate(),
     m_max_runtime(),
+    m_skip_start_iterations(0),
+    m_skip_end_iterations(0),
     m_number_of_publishers(),
     m_number_of_subscribers(),
     m_check_memory(false),
@@ -171,6 +179,8 @@ private:
   std::string m_topic_name;
 
   uint64_t m_max_runtime;
+  uint64_t m_skip_start_iterations;
+  uint64_t m_skip_end_iterations;
 
   uint32_t m_number_of_publishers;
   uint32_t m_number_of_subscribers;

--- a/performance_test/src/experiment_execution/analyze_runner.cpp
+++ b/performance_test/src/experiment_execution/analyze_runner.cpp
@@ -58,6 +58,8 @@ AnalyzeRunner::AnalyzeRunner()
 
 void AnalyzeRunner::run() const
 {
+  const uint64_t skip_from = m_ec.max_runtime() - m_ec.skip_end_iterations() - 1;
+  uint64_t current_iteration = 0;
   m_ec.log("---EXPERIMENT-START---");
   m_ec.log(AnalysisResult::csv_header(true));
 
@@ -80,7 +82,14 @@ void AnalyzeRunner::run() const
     auto now = std::chrono::steady_clock::now();
     auto loop_diff_start = now - loop_start;
     auto experiment_diff_start = now - experiment_start;
+    if (current_iteration < m_ec.skip_start_iterations() ||
+      (m_ec.max_runtime() > 0 && current_iteration > skip_from))
+    {
+      ++current_iteration;
+      continue;
+    }
     analyze(loop_diff_start, experiment_diff_start);
+    ++current_iteration;
   }
 }
 


### PR DESCRIPTION
As the title says, this PR enables the possibility to skip a given amount of iterations from the beginning and the end of the experiment

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/performance_test/92)
<!-- Reviewable:end -->
