### PR TITLE
Record version hash

### DIFF
--- a/performance_test/CMakeLists.txt
+++ b/performance_test/CMakeLists.txt
@@ -231,6 +231,14 @@ add_executable(${EXE_NAME} ${${PROJECT_NAME}_SOURCES} ${sources} ${${PROJECT_NAM
 
 set_compile_options(${EXE_NAME})
 
+# Try to bake the githash into the perf_test EXE:
+execute_process(
+  COMMAND ./version_check.bash
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE PERF_TEST_VERSION
+)
+add_definitions(-DPERFORMANCE_TEST_VERSION="${PERF_TEST_VERSION}")
+
 rosidl_target_interfaces(${EXE_NAME} ${PROJECT_NAME} "rosidl_typesupport_cpp")
 
 ament_target_dependencies(${EXE_NAME}

--- a/performance_test/helper_scripts/apex_performance_plotter/apex_performance_plotter/__init__.py
+++ b/performance_test/helper_scripts/apex_performance_plotter/apex_performance_plotter/__init__.py
@@ -100,7 +100,7 @@ def create_layout(header, dataframe):
         'Logfile name', 'Experiment id', 'Communication mean', 'Publishing rate',
         'Topic name', 'Number of publishers', 'Number of subscribers', 'Maximum runtime (sec)',
         'DDS domain id', 'QOS', 'Use ros SHM', 'Use single participant', 'Not using waitset',
-        'Not using Connext DDS Micro INTRA',
+        'Not using Connext DDS Micro INTRA', 'perf_test version',
     }
 
     header.update(dict('QOS {}'.format(x).split(': ')
@@ -140,6 +140,7 @@ def create_layout(header, dataframe):
         ),
         'categories': [
             {'name': 'test setup', 'items': [
+                create_kv(header, 'perf_test version'),
                 create_kv(header, 'Publishing rate'),
                 create_kv(header, 'Topic name'),
                 create_kv(header, 'Number of publishers'),
@@ -150,10 +151,6 @@ def create_layout(header, dataframe):
                 create_kv(header, 'Use single participant', boolish=True),
                 create_kv(header, 'Not using waitset', boolish=True),
                 create_kv(header, 'Not using Connext DDS Micro INTRA', boolish=True),
-                create_kv(header, 'QOS Reliability'),
-                create_kv(header, 'QOS Durability'),
-                create_kv(header, 'QOS History kind'),
-                create_kv(header, 'QOS History depth'),
             ]},
             {'name': 'average results', 'items': [
                 {'key': 'Experiment Status', 'value': 'success' if xaxis else 'failed'},
@@ -161,7 +158,7 @@ def create_layout(header, dataframe):
                   if key != 'T_experiment' and not key.startswith('ru_')],
             ]},
             {'name': 'environment', 'items': [
-                *[create_kv(header, key) for key in set(header.keys()) - header_fields],
+                *[create_kv(header, key) for key in sorted(set(header.keys()) - header_fields)],
             ]},
         ],
     }

--- a/performance_test/include/performance_test/version.h
+++ b/performance_test/include/performance_test/version.h
@@ -1,10 +1,24 @@
-#ifndef PERFORMANCE_TEST_VERSION_H
-#define PERFORMANCE_TEST_VERSION_H
+// Copyright 2019 Apex.AI, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PERFORMANCE_TEST__VERSION_H_
+#define PERFORMANCE_TEST__VERSION_H_
 
 #ifdef PERFORMANCE_TEST_VERSION
-const char* version = PERFORMANCE_TEST_VERSION;
+const char * version = PERFORMANCE_TEST_VERSION;
 #else
-const char* version = "unknown";
+const char * version = "unknown";
 #endif
 
-#endif
+#endif  // PERFORMANCE_TEST__VERSION_H_

--- a/performance_test/include/performance_test/version.h
+++ b/performance_test/include/performance_test/version.h
@@ -1,0 +1,10 @@
+#ifndef PERFORMANCE_TEST_VERSION_H
+#define PERFORMANCE_TEST_VERSION_H
+
+#ifdef PERFORMANCE_TEST_VERSION
+const char* version = PERFORMANCE_TEST_VERSION;
+#else
+const char* version = "unknown";
+#endif
+
+#endif

--- a/performance_test/src/experiment_configuration/experiment_configuration.cpp
+++ b/performance_test/src/experiment_configuration/experiment_configuration.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "experiment_configuration.hpp"
+#include "performance_test/version.h"
 
 #include <boost/program_options.hpp>
 
@@ -44,6 +45,7 @@ std::ostream & operator<<(std::ostream & stream, const ExperimentConfiguration &
   if (e.is_setup()) {
     return stream <<
            "Experiment id: " << e.id() <<
+           "\nperf_test version: " << version <<
            "\nLogfile name: " << e.logfile_name() <<
            "\nCommunication mean: " << e.com_mean() <<
            "\nDDS domain id: " << e.dds_domain_id() <<
@@ -135,6 +137,7 @@ void ExperimentConfiguration::setup(int argc, char ** argv)
     }
 
     if (vm.count("help")) {
+      std::cout << "Version: " << version << "\n";
       std::cout << desc << "\n";
       exit(0);
     }

--- a/performance_test/src/experiment_configuration/experiment_configuration.cpp
+++ b/performance_test/src/experiment_configuration/experiment_configuration.cpp
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 #include "experiment_configuration.hpp"
-#include "performance_test/version.h"
 
 #include <boost/program_options.hpp>
-
 #include <rclcpp/rclcpp.hpp>
 
 #include <iostream>
@@ -25,6 +23,8 @@
 #include <string>
 
 #include "topics.hpp"
+
+#include "performance_test/version.h"
 
 namespace performance_test
 {

--- a/performance_test/version_check.bash
+++ b/performance_test/version_check.bash
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+REV=$(git rev-parse --short HEAD)
+if [[ `git status --porcelain` ]]; then
+  REV="$REV-dirty"
+fi
+printf $REV


### PR DESCRIPTION
 - Bake performance_test into the perf_test EXE so it can show up as part of the report
 - Have the perf_plot tool recognize the version and print it in the "test setup" section of the report
 - Remove duplciate QOS settings from the 'test setup' section of the report

I also tested what happens if you blow away the .git directory and build performance_test.  The tool will still build, but the version shows up as blank.

Here is a report generated with the changes in this PR:
![image](https://user-images.githubusercontent.com/4884343/66153211-f0a75580-e5cf-11e9-8278-4dbcef255196.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/performance_test/93)
<!-- Reviewable:end -->
