### PR TITLE
Add fix for incorrect values for variance

### DIFF
--- a/performance_test/src/utilities/statistics_tracker.hpp
+++ b/performance_test/src/utilities/statistics_tracker.hpp
@@ -34,7 +34,8 @@ public:
     m_max(std::numeric_limits<double>::lowest()),
     m_n(0.0),
     m_mean(0.0),
-    m_M2(0.0)
+    m_M2(0.0),
+    m_variance(0.0)
   {
     static_assert(std::numeric_limits<double>::is_iec559, "Non IEEE754 are not supported.");
   }
@@ -47,7 +48,8 @@ public:
     m_max(std::numeric_limits<double>::lowest()),
     m_n(0.0),
     m_mean(0.0),
-    m_M2(0.0)
+    m_M2(0.0),
+    m_variance(0.0)
   {
     if (st_vec.empty()) {
       return;
@@ -59,6 +61,7 @@ public:
       m_n = a.m_n;
       m_mean = a.m_mean;
       m_M2 = a.m_M2;
+      m_variance = m_M2 / m_n;
       return;
     }
     double mean_t = 0.0, n_total = 0.0;


### PR DESCRIPTION
Adding fix to print correct values for `latency_variance (ms)` , `pub_loop_res_variance (ms) `, `sub_loop_res_variance (ms)` . The bug got introduced due to changes in : https://github.com/ApexAI/performance_test/pull/84

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/performance_test/94)
<!-- Reviewable:end -->
