### PR TITLE
Allow use of another SYSROOT

### DIFF
--- a/tools/toolchain.cmake
+++ b/tools/toolchain.cmake
@@ -1,8 +1,17 @@
 set(CMAKE_C_COMPILER /usr/bin/aarch64-linux-gnu-gcc)
 set(CMAKE_CXX_COMPILER /usr/bin/aarch64-linux-gnu-g++)
-set(CMAKE_SYSROOT /sysroot/)
 
-set(CMAKE_FIND_ROOT_PATH /sysroot)
+if(DEFINED ENV{SYSROOT})
+  set(_SYSROOT $ENV{SYSROOT})
+else()
+  # Github CI expects this to be set automatically.  Other CI might want to set its own
+  # SYSROOT
+  set(_SYSROOT /sysroot)
+endif()
+
+set(CMAKE_SYSROOT ${_SYSROOT})
+
+set(CMAKE_FIND_ROOT_PATH ${_SYSROOT})
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)


### PR DESCRIPTION
Make it possible to use other SYSROOTs other than `/sysroot`

Signed-off-by: Pete Baughman <pete.baughman@apex.ai>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/performance_test/95)
<!-- Reviewable:end -->
