### PR TITLE
Print RMW implementation in log

### DIFF
--- a/performance_test/helper_scripts/apex_performance_plotter/apex_performance_plotter/__init__.py
+++ b/performance_test/helper_scripts/apex_performance_plotter/apex_performance_plotter/__init__.py
@@ -100,7 +100,7 @@ def create_layout(header, dataframe):
         'Logfile name', 'Experiment id', 'Communication mean', 'Publishing rate',
         'Topic name', 'Number of publishers', 'Number of subscribers', 'Maximum runtime (sec)',
         'DDS domain id', 'QOS', 'Use ros SHM', 'Use single participant', 'Not using waitset',
-        'Not using Connext DDS Micro INTRA', 'perf_test version',
+        'Not using Connext DDS Micro INTRA', 'Performance Test Version',
     }
 
     header.update(dict('QOS {}'.format(x).split(': ')
@@ -140,7 +140,7 @@ def create_layout(header, dataframe):
         ),
         'categories': [
             {'name': 'test setup', 'items': [
-                create_kv(header, 'perf_test version'),
+                create_kv(header, 'Performance Test Version'),
                 create_kv(header, 'Publishing rate'),
                 create_kv(header, 'Topic name'),
                 create_kv(header, 'Number of publishers'),

--- a/performance_test/include/performance_test/version.h
+++ b/performance_test/include/performance_test/version.h
@@ -16,9 +16,9 @@
 #define PERFORMANCE_TEST__VERSION_H_
 
 #ifdef PERFORMANCE_TEST_VERSION
-const char * version = PERFORMANCE_TEST_VERSION;
+const std::string version = PERFORMANCE_TEST_VERSION;
 #else
-const char * version = "unknown";
+const std::string version = "unknown";
 #endif
 
 #endif  // PERFORMANCE_TEST__VERSION_H_

--- a/performance_test/include/performance_test/version.h
+++ b/performance_test/include/performance_test/version.h
@@ -16,9 +16,9 @@
 #define PERFORMANCE_TEST__VERSION_H_
 
 #ifdef PERFORMANCE_TEST_VERSION
-const std::string version = PERFORMANCE_TEST_VERSION;
+const char * version = PERFORMANCE_TEST_VERSION;
 #else
-const std::string version = "unknown";
+const char * version = "unknown";
 #endif
 
 #endif  // PERFORMANCE_TEST__VERSION_H_

--- a/performance_test/src/experiment_configuration/experiment_configuration.cpp
+++ b/performance_test/src/experiment_configuration/experiment_configuration.cpp
@@ -16,6 +16,7 @@
 
 #include <boost/program_options.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <rmw/rmw.h>
 
 #include <iostream>
 #include <iomanip>
@@ -48,6 +49,7 @@ std::ostream & operator<<(std::ostream & stream, const ExperimentConfiguration &
            "\nperf_test version: " << version <<
            "\nLogfile name: " << e.logfile_name() <<
            "\nCommunication mean: " << e.com_mean() <<
+           "\nRMW Implementation: " << rmw_get_implementation_identifier() <<
            "\nDDS domain id: " << e.dds_domain_id() <<
            "\nQOS: " << e.qos() <<
            "\nPublishing rate: " << e.rate() <<

--- a/performance_test/src/experiment_configuration/experiment_configuration.cpp
+++ b/performance_test/src/experiment_configuration/experiment_configuration.cpp
@@ -46,10 +46,10 @@ std::ostream & operator<<(std::ostream & stream, const ExperimentConfiguration &
   if (e.is_setup()) {
     return stream <<
            "Experiment id: " << e.id() <<
-           "\nperf_test version: " << version <<
+           "\nPerformance Test Version: " << e.perf_test_version() <<
            "\nLogfile name: " << e.logfile_name() <<
            "\nCommunication mean: " << e.com_mean() <<
-           "\nRMW Implementation: " << rmw_get_implementation_identifier() <<
+           "\nRMW Implementation: " << e.rmw_implementation() <<
            "\nDDS domain id: " << e.dds_domain_id() <<
            "\nQOS: " << e.qos() <<
            "\nPublishing rate: " << e.rate() <<
@@ -128,6 +128,7 @@ void ExperimentConfiguration::setup(int argc, char ** argv)
   ;
   po::variables_map vm;
   po::store(parse_command_line(argc, argv, desc), vm);
+  m_perf_test_version = version;
 
   try {
     if (vm.count("topic_list")) {
@@ -139,7 +140,7 @@ void ExperimentConfiguration::setup(int argc, char ** argv)
     }
 
     if (vm.count("help")) {
-      std::cout << "Version: " << version << "\n";
+      std::cout << "Version: " << perf_test_version() << "\n";
       std::cout << desc << "\n";
       exit(0);
     }
@@ -299,6 +300,8 @@ void ExperimentConfiguration::setup(int argc, char ** argv)
         throw std::invalid_argument("Invalid roundtrip mode: " + mode);
       }
     }
+    m_rmw_implementation = rmw_get_implementation_identifier();
+
 #ifdef PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED
     if (vm.count("db_name")) {
       m_db_name = vm["db_name"].as<std::string>();
@@ -451,6 +454,18 @@ ExperimentConfiguration::RoundTripMode ExperimentConfiguration::roundtrip_mode()
 {
   check_setup();
   return m_roundtrip_mode;
+}
+
+std::string ExperimentConfiguration::rmw_implementation() const
+{
+  check_setup();
+  return m_rmw_implementation;
+}
+
+std::string ExperimentConfiguration::perf_test_version() const
+{
+  check_setup();
+  return m_perf_test_version;
 }
 
 std::string ExperimentConfiguration::pub_topic_postfix() const

--- a/performance_test/src/experiment_configuration/experiment_configuration.hpp
+++ b/performance_test/src/experiment_configuration/experiment_configuration.hpp
@@ -128,6 +128,11 @@ public:
   bool is_with_security() const;
   /// \returns Returns the roundtrip mode.
   RoundTripMode roundtrip_mode() const;
+  /// \returns Returns current rmw_implementation. This will throw if the experiment configuration is not set up.
+  std::string rmw_implementation() const;
+  /// \returns Returns current performance test version. This will throw if the experiment
+  // configuration is not set up.
+  std::string perf_test_version() const;
   /// \returns Returns the publishing topic postfix
   std::string pub_topic_postfix() const;
   /// \returns Returns the subscribing topic postfix
@@ -226,6 +231,9 @@ private:
   bool m_with_security;
 
   RoundTripMode m_roundtrip_mode;
+
+  std::string m_rmw_implementation;
+  std::string m_perf_test_version;
 
 #ifdef PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED
   #pragma db value_not_null inverse(m_configuration)

--- a/performance_test/src/experiment_configuration/experiment_configuration.hpp
+++ b/performance_test/src/experiment_configuration/experiment_configuration.hpp
@@ -128,7 +128,8 @@ public:
   bool is_with_security() const;
   /// \returns Returns the roundtrip mode.
   RoundTripMode roundtrip_mode() const;
-  /// \returns Returns current rmw_implementation. This will throw if the experiment configuration is not set up.
+  /// \returns Returns current rmw_implementation. This will throw if the experiment configuration
+  /// is not set up.
   std::string rmw_implementation() const;
   /// \returns Returns current performance test version. This will throw if the experiment
   // configuration is not set up.


### PR DESCRIPTION
This calls the `rmw.h` function `rmw_get_implementation_identifier` so the resulting graph of the test results can include the RMW implementation.

[log_Array1k_11-10-2019_10-58-42.pdf](https://github.com/ApexAI/performance_test/files/3719017/log_Array1k_11-10-2019_10-58-42.pdf)

In the attached report, notice that the information is included in the `environment` section in the lower-right

Signed-off-by: Pete Baughman <pete.baughman@apex.ai>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/performance_test/97)
<!-- Reviewable:end -->
