### PR TITLE
Compute cpu load % for running experiments and log in the result csv and generated plots

### DIFF
--- a/performance_test/CMakeLists.txt
+++ b/performance_test/CMakeLists.txt
@@ -193,6 +193,7 @@ set(sources
     src/utilities/rt_enabler.hpp
     src/utilities/spin_lock.hpp
     src/utilities/statistics_tracker.hpp
+    src/utilities/cpu_usage_tracker.hpp
 )
 
 # ROS2 Waitset

--- a/performance_test/helper_scripts/apex_performance_plotter/apex_performance_plotter/__init__.py
+++ b/performance_test/helper_scripts/apex_performance_plotter/apex_performance_plotter/__init__.py
@@ -117,6 +117,7 @@ def create_layout(header, dataframe):
     y21 = dataframe['ru_minflt'].tolist()
     y22 = dataframe['ru_majflt'].tolist()
     y23 = dataframe['ru_nivcsw'].tolist()
+    y24 = dataframe['cpu_usage (%)'].tolist()
 
     means = dataframe.mean().round(4)
 
@@ -136,7 +137,8 @@ def create_layout(header, dataframe):
             yr11,
             y21,
             y22,
-            y23
+            y23,
+            y24
         ),
         'categories': [
             {'name': 'test setup', 'items': [

--- a/performance_test/helper_scripts/apex_performance_plotter/apex_performance_plotter/generate_plots.py
+++ b/performance_test/helper_scripts/apex_performance_plotter/apex_performance_plotter/generate_plots.py
@@ -24,6 +24,7 @@ def generate_figures(xaxis,
                      minflt_ydata,
                      majflt_ydata,
                      nivcsw_ydata,
+                     cpu_usage_ydata,
                      ):
     """
     Generate the figures for a perf_plot PDF.
@@ -63,9 +64,10 @@ def generate_figures(xaxis,
                 {'name': 'ru_minflt', 'x': xaxis, 'y': minflt_ydata},
                 {'name': 'ru_majflt', 'x': xaxis, 'y': majflt_ydata},
                 {'name': 'ru_nivcsw', 'x': xaxis, 'y': nivcsw_ydata},
+                {'name': 'cpu(%)', 'x': xaxis, 'y': cpu_usage_ydata},
             ],
             'xrange': get_range(5, xaxis),
-            'yrange': get_range(2500, minflt_ydata, majflt_ydata, nivcsw_ydata),
+            'yrange': get_range(2500, minflt_ydata, majflt_ydata, nivcsw_ydata, cpu_usage_ydata),
             'axis2': {
                 'ylabel': 'maxrss (MB)',
                 'traces': [

--- a/performance_test/src/experiment_execution/analysis_result.cpp
+++ b/performance_test/src/experiment_execution/analysis_result.cpp
@@ -14,6 +14,8 @@
 
 #include "analysis_result.hpp"
 
+#include <sys/times.h>
+
 #include <iomanip>
 #include <string>
 #include <iostream>
@@ -35,7 +37,8 @@ AnalysisResult::AnalysisResult(
   const std::size_t total_data_received,
   const StatisticsTracker latency,
   const StatisticsTracker pub_loop_time_reserve,
-  const StatisticsTracker sub_loop_time_reserve
+  const StatisticsTracker sub_loop_time_reserve,
+  const CpuInfo cpu_info
 )
 : m_experiment_start(experiment_start),
   m_loop_start(loop_start),
@@ -45,7 +48,8 @@ AnalysisResult::AnalysisResult(
   m_total_data_received(total_data_received),
   m_latency(latency),
   m_pub_loop_time_reserve(pub_loop_time_reserve),
-  m_sub_loop_time_reserve(sub_loop_time_reserve)
+  m_sub_loop_time_reserve(sub_loop_time_reserve),
+  m_cpu_info(cpu_info)
 {
   const auto ret = getrusage(RUSAGE_SELF, &m_sys_usage);
 #ifdef PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED
@@ -61,6 +65,7 @@ AnalysisResult::AnalysisResult(
                              + std::to_string(m_latency.n()));*/
   }
 }
+
 
 std::string AnalysisResult::csv_header(const bool pretty_print, std::string st)
 {
@@ -109,6 +114,8 @@ std::string AnalysisResult::csv_header(const bool pretty_print, std::string st)
   ss << "ru_nsignals" << st;
   ss << "ru_nvcsw" << st;
   ss << "ru_nivcsw" << st;
+
+  ss << "cpu_usage (%)" << st;
 
   return ss.str();
 }
@@ -171,6 +178,8 @@ std::string AnalysisResult::to_csv_string(const bool pretty_print, std::string s
   ss << m_sys_usage.ru_nsignals << st;
   ss << m_sys_usage.ru_nvcsw << st;
   ss << m_sys_usage.ru_nivcsw << st;
+
+  ss << m_cpu_info.cpu_usage() << st;
 
   return ss.str();
 }

--- a/performance_test/src/experiment_execution/analysis_result.hpp
+++ b/performance_test/src/experiment_execution/analysis_result.hpp
@@ -23,6 +23,8 @@
 #include <string>
 
 #include "../utilities/statistics_tracker.hpp"
+#include "../utilities/cpu_usage_tracker.hpp"
+
 #ifdef PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED
   #include <odb/core.hxx>
   #include "experiment_configuration.hpp"
@@ -107,7 +109,8 @@ public:
     const std::size_t total_data_received,
     const StatisticsTracker latency,
     const StatisticsTracker pub_loop_time_reserve,
-    const StatisticsTracker sub_loop_time_reserve
+    const StatisticsTracker sub_loop_time_reserve,
+    const CpuInfo cpu_info
   );
 #ifdef PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED
   AnalysisResult() {}
@@ -158,6 +161,7 @@ private:
 #pragma db transient
 #endif
   rusage m_sys_usage;
+  const CpuInfo m_cpu_info;
 };
 
 }  // namespace performance_test

--- a/performance_test/src/experiment_execution/analyze_runner.cpp
+++ b/performance_test/src/experiment_execution/analyze_runner.cpp
@@ -99,7 +99,7 @@ AnalyzeRunner::AnalyzeRunner()
 #endif
 }
 
-void AnalyzeRunner::run() const
+void AnalyzeRunner::run()
 {
   m_ec.log("---EXPERIMENT-START---");
   m_ec.log(AnalysisResult::csv_header(true));
@@ -138,7 +138,7 @@ void AnalyzeRunner::run() const
 
 void AnalyzeRunner::analyze(
   const std::chrono::nanoseconds loop_diff_start,
-  const std::chrono::nanoseconds experiment_diff_start) const
+  const std::chrono::nanoseconds experiment_diff_start)
 {
   std::vector<StatisticsTracker> latency_vec(m_sub_runners.size());
   std::transform(m_sub_runners.begin(), m_sub_runners.end(), latency_vec.begin(),
@@ -181,7 +181,8 @@ void AnalyzeRunner::analyze(
     sum_data_received,
     StatisticsTracker(latency_vec),
     StatisticsTracker(ltr_pub_vec),
-    StatisticsTracker(ltr_sub_vec)
+    StatisticsTracker(ltr_sub_vec),
+    cpu_usage_tracker.get_cpu_usage()
   );
 
   m_ec.log(result->to_csv_string(true));

--- a/performance_test/src/experiment_execution/analyze_runner.hpp
+++ b/performance_test/src/experiment_execution/analyze_runner.hpp
@@ -22,6 +22,7 @@
 #include "analysis_result.hpp"
 #include "../data_running/data_runner_factory.hpp"
 #include "../experiment_configuration/experiment_configuration.hpp"
+#include "../utilities/cpu_usage_tracker.hpp"
 
 #ifdef PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED
   #include <odb/database.hxx>
@@ -44,7 +45,7 @@ public:
   /**
    * \brief Runs the experiment.
    */
-  void run() const;
+  void run();
 
 private:
   /**
@@ -55,7 +56,7 @@ private:
 
   void analyze(
     const std::chrono::nanoseconds loop_diff_start,
-    const std::chrono::nanoseconds experiment_diff_start) const;
+    const std::chrono::nanoseconds experiment_diff_start);
 
   /**
    * \brief Checks if the experiment is finished.
@@ -69,6 +70,7 @@ private:
   std::vector<std::shared_ptr<DataRunnerBase>> m_pub_runners;
   std::vector<std::shared_ptr<DataRunnerBase>> m_sub_runners;
   mutable bool m_is_first_entry;
+  CPUsageTracker cpu_usage_tracker;
 
 #ifdef PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED
   std::unique_ptr<odb::core::database> m_db;

--- a/performance_test/src/utilities/cpu_usage_tracker.hpp
+++ b/performance_test/src/utilities/cpu_usage_tracker.hpp
@@ -1,0 +1,310 @@
+// Copyright 2017 Apex.AI, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef UTILITIES__CPU_USAGE_TRACKER_HPP_
+#define UTILITIES__CPU_USAGE_TRACKER_HPP_
+
+
+#include <sys/times.h>
+#include <sys/types.h>
+
+#include <unistd.h>
+
+#include <fstream>
+#include <utility>
+#include <string>
+#include <vector>
+
+namespace performance_test
+{
+
+struct CpuInfo
+{
+  CpuInfo(uint32_t cpu_cores, float_t cpu_usage)
+  : m_cpu_cores(cpu_cores), m_cpu_usage(cpu_usage) {}
+
+  uint32_t cpu_cores() const
+  {
+    return m_cpu_cores;
+  }
+
+  float_t cpu_usage() const
+  {
+    return m_cpu_usage;
+  }
+
+private:
+  uint32_t m_cpu_cores;
+  float_t m_cpu_usage;
+};
+
+///  Calculate the CPU usage for the running experiment in the performance test
+class CPUsageTracker
+{
+public:
+  CPUsageTracker()
+  : proc_stat_file("/proc/stat", std::ifstream::in) {}
+
+  /**
+* \brief Computes the CPU usage % as (process_active_time/total_cpu_time)*100
+* This throws an exception if the total time is not updated
+*
+*/
+  CpuInfo get_cpu_usage()
+  {
+    // get process cpu times from http://man7.org/linux/man-pages/man2/times.2.html
+    const auto retval = times(&m_process_cpu_times);
+    if (retval == -1) {
+      throw std::runtime_error("Could not get process CPU times.");
+    }
+
+    // compute total process time
+    const int64_t process_active_time = m_process_cpu_times.tms_cstime + m_process_cpu_times
+      .tms_cutime +
+      m_process_cpu_times.tms_stime +
+      m_process_cpu_times.tms_utime;
+
+    // get total CPU times from http://man7.org/linux/man-pages/man5/proc.5.html
+    const auto bundle = read_total_cpu_times();
+    const int64_t cpu_total_time = bundle.first;
+    float_t cpu_usage_local{};
+
+    // active time and total time are valid
+    if ((process_active_time > 0) &&
+      (cpu_total_time > 0) &&
+      (cpu_total_time >= process_active_time))
+    {
+      // The CPU times should always be incrementing
+      if ((process_active_time >= m_prev_active_time) &&
+        (cpu_total_time >= m_prev_total_time))
+      {
+        // The diff should never be negative
+        const int64_t active_time_diff = process_active_time - m_prev_active_time;
+        const int64_t total_time_diff = cpu_total_time - m_prev_total_time;
+        // compute CPU usage
+        if (active_time_diff != 0) {  // if the active time diff is non zero
+          if (total_time_diff != 0) {  // if the total time diff is non zero
+            cpu_usage_local =
+              (static_cast<float_t>(active_time_diff) /
+              static_cast<float_t>(total_time_diff)) * 100.0F;
+          } else {  // when the total time diff is 0
+            // this should never happen
+            throw std::runtime_error("get_cpu_usage: CPU times are not updated!");
+          }
+        } else {
+          if (total_time_diff != 0) {
+            // when the active time diff is 0 and total time diff is non 0
+            // CPU if completely idle (ideal case)
+            cpu_usage_local = 0.0F;
+          } else {  // when the total time diff is 0
+            // this should never happen
+            throw std::runtime_error("get_cpu_usage: CPU times are not updated!");
+          }
+        }
+
+        // update previous times
+        m_prev_active_time = process_active_time;
+        m_prev_total_time = cpu_total_time;
+
+        CpuInfo cpu_info_local{bundle.second, cpu_usage_local};
+        return cpu_info_local;
+
+      } else {
+        throw std::invalid_argument("get_cpu_usage: time travelled backwards.");
+      }
+    } else {
+      throw std::invalid_argument("get_cpu_usage: process_active_time > cpu_total_time");
+    }
+  }
+
+private:
+  /**
+* \brief Class for specifying CPU Time states.
+*
+*  The class CpuTimeState is used for specifying the index from which to parse
+*  the specific CPU time from `/proc/stat` output.
+*
+*  e.g. user nice system idle iowait  irq  softirq steal guest guest_nice
+*  cpu  4705 356  584    3699   23    23     0       0     0          0
+*/
+  class CpuTimeState
+  {
+public:
+    /**
+   * \brief Overloaded istream operator to parse contents of `/proc/stat` file
+   */
+    explicit CpuTimeState(std::istream & stream)
+    {
+      stream >> m_cpu_label >>
+      m_cs_user >>
+      m_cs_nice >>
+      m_cs_system >>
+      m_cs_idle >>
+      m_cs_iowait >>
+      m_cs_irq >>
+      m_cs_softirq >>
+      m_cs_steal;
+    }
+
+    /**
+    * \brief Calculates the total cpu time since boot
+    */
+    int64_t compute_total_cpu_time() const
+    {
+      return m_cs_user + m_cs_nice + m_cs_system + m_cs_idle + m_cs_iowait + m_cs_irq +
+             m_cs_softirq + m_cs_steal;
+    }
+
+
+    int64_t cs_user() const
+    {
+      return m_cs_user;
+    }
+
+    int64_t cs_nice() const
+    {
+      return m_cs_nice;
+    }
+
+    int64_t cs_system() const
+    {
+      return m_cs_system;
+    }
+
+    int64_t cs_idle() const
+    {
+      return m_cs_idle;
+    }
+
+    int64_t cs_iowait() const
+    {
+      return m_cs_iowait;
+    }
+
+    int64_t cs_irq() const
+    {
+      return m_cs_irq;
+    }
+
+    int64_t cs_softirq() const
+    {
+      return m_cs_softirq;
+    }
+
+    int64_t cs_steal() const
+    {
+      return m_cs_steal;
+    }
+
+    int64_t cs_guest() const
+    {
+      return m_cs_guest;
+    }
+
+    int64_t cs_guest_nice() const
+    {
+      return m_cs_guest_nice;
+    }
+
+    std::string cpu_label() const
+    {
+      return m_cpu_label;
+    }
+
+private:
+    /// Time spent in user mode
+    int64_t m_cs_user{};
+    /// Time spent in user mode with low priority ("nice")
+    int64_t m_cs_nice{};
+    /// Time spent in system mode
+    int64_t m_cs_system{};
+    /// Time spent in idle task
+    int64_t m_cs_idle{};
+    /// Time waiting for I/O to complete
+    int64_t m_cs_iowait{};
+    /// Time spent in servicing interrupts
+    int64_t m_cs_irq{};
+    /// Time spent in servicing soft irq's
+    int64_t m_cs_softirq{};
+    /// Time spent in other OS (stolen time)
+    int64_t m_cs_steal{};
+    /// Time spent for running virtual CPU for guest OS
+    int64_t m_cs_guest{};
+    /// Time spent for running virtual CPU with nice prio for guest OS
+    int64_t m_cs_guest_nice{};
+    /// Cpu label (cpu 0 ,cpu 1 ..)
+    std::string m_cpu_label{};
+  };
+
+  int64_t m_prev_active_time{};
+  int64_t m_prev_total_time{};
+  tms m_process_cpu_times;
+  std::ifstream proc_stat_file;
+
+  /**
+  * \brief Vector for storing cpu information
+  *
+  * This vector is used to store the cpu label (cpu 0, cpu1 ..etc) along with the cpu ticks in
+  * cpu_time_array for different CPU usages as defined by CpuTimeState struct above.
+  *
+  */
+  std::vector<CpuTimeState> m_entries{};
+
+  /**
+ * \brief Reads the total cpu time.
+ *
+ *  This function parses the output of /proc/stat which contains information on cpu time spent
+ *  since boot. It computes the total CPU time since boot as well as counts the number of CPU
+ *  cores and returns a bundle of both.
+ *
+ */
+  std::pair<int64_t, uint32_t> read_total_cpu_times()
+  {
+    std::string line;
+    const std::string cpu_string("cpu");
+    const std::size_t cpu_string_len = cpu_string.size();
+    int64_t cpu_total_time {};
+    uint32_t num_cpu_cores {};
+    while (std::getline(proc_stat_file, line)) {
+      // cpu stats line found
+      if (!line.compare(0, cpu_string_len, cpu_string)) {
+        std::istringstream ss(line);
+        // store entry
+        CpuTimeState entry(ss);
+        // count the number of cpu cores
+        if (entry.cpu_label().size() > cpu_string_len) {
+          ++num_cpu_cores;
+        }
+        // read times
+        m_entries.push_back(entry);
+      }
+    }
+    // compute cpu total time
+    // Guest and Guest_nice are not included in the total time calculation since they are
+    // already accounted in user and nice.
+
+    cpu_total_time = m_entries[0].compute_total_cpu_time();
+
+    // Clear entries vector for next iteration
+    m_entries.clear();
+    // Reset the eof file flag and move file pointer to beginning for next read
+    proc_stat_file.clear();
+    proc_stat_file.seekg(0, std::ifstream::beg);
+    std::pair<int64_t, uint32_t> bundle {cpu_total_time, num_cpu_cores};
+    return bundle;
+  }
+};
+}  // namespace performance_test
+
+#endif  // UTILITIES__CPU_USAGE_TRACKER_HPP_


### PR DESCRIPTION
This PR contains changes to :
1. Compute the %CPU load for the experiments running as part of performance test 
2. Add a new column in performance test results csv called `cpu usage(%)` logging the cpu load.
3. Plot the CPU usage along with printing the average load seen during the experiment as part of the pdf generated.

The new column added can be seen in the screenshot below with the load values logged throughout the experiment run:
![image](https://user-images.githubusercontent.com/15241291/66691808-d57eba80-ec4d-11e9-9d29-3d0c58e54bc9.png)

The `cpu usage(%)` is seen as part of the generated pdf on the usage graph on the right plotted as a blue line and also a new field called `cpu usage(%)` is seen as part of `average results` section of the report.

![image](https://user-images.githubusercontent.com/15241291/66691870-55a52000-ec4e-11e9-8c8e-5574322f5da9.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/performance_test/99)
<!-- Reviewable:end -->
