### PR TITLE
Add a toolchain that doesn't require copying artifacts to sysroot

### DIFF
--- a/tools/toolchain_arm.cmake
+++ b/tools/toolchain_arm.cmake
@@ -1,0 +1,21 @@
+set(CMAKE_C_COMPILER /usr/bin/aarch64-linux-gnu-gcc)
+set(CMAKE_CXX_COMPILER /usr/bin/aarch64-linux-gnu-g++)
+
+if(DEFINED ENV{SYSROOT})
+  set(_SYSROOT $ENV{SYSROOT})
+else()
+  # Github CI expects this to be set automatically.  Other CI might want to set its own
+  # SYSROOT
+  set(_SYSROOT /sysroot)
+endif()
+
+set(CMAKE_SYSROOT ${_SYSROOT})
+
+# CMAKE_FIND_ROOT_PATH only accept semi-colon separated list
+string(REPLACE ":" ";" _CMAKE_PREFIX_PATH "$ENV{CMAKE_PREFIX_PATH}")
+
+set(CMAKE_FIND_ROOT_PATH ${_CMAKE_PREFIX_PATH})
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)


### PR DESCRIPTION
  - The github CI job expects to copy ROS binaries into the sysroot directory
  - toolchain_arm.cmake works with CI that doesn't do this step

Signed-off-by: Pete Baughman <pete.baughman@apex.ai>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/performance_test/101)
<!-- Reviewable:end -->
