### PR TITLE
Don't error out on --help

### DIFF
--- a/performance_test/src/experiment_configuration/experiment_configuration.cpp
+++ b/performance_test/src/experiment_configuration/experiment_configuration.cpp
@@ -464,7 +464,6 @@ std::string ExperimentConfiguration::rmw_implementation() const
 
 std::string ExperimentConfiguration::perf_test_version() const
 {
-  check_setup();
   return m_perf_test_version;
 }
 


### PR DESCRIPTION
See https://github.com/ApexAI/performance_test/pull/97#issuecomment-542323712 for background

This check_setup was causing `perf_test --help` to fail with a non-zero exit code

Signed-off-by: Pete Baughman <pete.baughman@apex.ai>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/performance_test/103)
<!-- Reviewable:end -->
