### PR TITLE
Fix error in odb after adding cpu_info

### DIFF
--- a/performance_test/src/experiment_execution/analysis_result.hpp
+++ b/performance_test/src/experiment_execution/analysis_result.hpp
@@ -81,6 +81,7 @@ private:
 #pragma db value(RusageTracker) definition
 #pragma db value(rusage) definition
 #pragma db value(timeval) definition
+#pragma db value(CpuInfo) definition
 
 /// Represents the results of an experiment iteration.
 #pragma db object pointer(std::shared_ptr)

--- a/performance_test/src/utilities/cpu_usage_tracker.hpp
+++ b/performance_test/src/utilities/cpu_usage_tracker.hpp
@@ -26,6 +26,10 @@
 #include <string>
 #include <vector>
 
+#ifdef PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED
+#include <odb/core.hxx>
+#endif
+
 namespace performance_test
 {
 
@@ -33,6 +37,10 @@ struct CpuInfo
 {
   CpuInfo(uint32_t cpu_cores, float_t cpu_usage)
   : m_cpu_cores(cpu_cores), m_cpu_usage(cpu_usage) {}
+
+#ifdef PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED
+  CpuInfo() {}
+#endif
 
   uint32_t cpu_cores() const
   {
@@ -45,6 +53,9 @@ struct CpuInfo
   }
 
 private:
+#ifdef PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED
+  friend class odb::access;
+#endif
   uint32_t m_cpu_cores;
   float_t m_cpu_usage;
 };


### PR DESCRIPTION
After creating a separate class `CpuInfo`, we need to add this class as a `odb::friend` to see the values in the database. Here I add small fixes that enable saving cpu info data into a database.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/performance_test/106)
<!-- Reviewable:end -->
