### PR TITLE
Have performance_test add the path to ODB to env

### DIFF
--- a/performance_test/CMakeLists.txt
+++ b/performance_test/CMakeLists.txt
@@ -120,6 +120,10 @@ if(PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED)
   list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
   find_package(ODB REQUIRED COMPONENTS sqlite OPTIONAL_COMPONENTS mysql pgsql)
   include(${ODB_USE_FILE})
+
+  # Get the setup.sh to update the LD_LIBRARY_PATH
+  get_filename_component(ODB_LIBRARY_DIRECTORY ${ODB_LIBODB_LIBRARIES} DIRECTORY)
+  ament_environment_hooks(env_hook/odb_library_path.sh.in)
 endif()
 
 set(${PROJECT_NAME}_SOURCES

--- a/performance_test/env_hook/odb_library_path.sh.in
+++ b/performance_test/env_hook/odb_library_path.sh.in
@@ -1,0 +1,17 @@
+# copied from ament_package/template/environment_hook/library_path.sh
+_ODB_LIBRARY_DIR="@ODB_LIBRARY_DIRECTORY@"
+
+# detect if running on Darwin platform
+_UNAME=`uname -s`
+_IS_DARWIN=0
+if [ "$_UNAME" = "Darwin" ]; then
+  _IS_DARWIN=1
+fi
+unset _UNAME
+
+if [ $_IS_DARWIN -eq 0 ]; then
+  ament_prepend_unique_value LD_LIBRARY_PATH "$_ODB_LIBRARY_DIR"
+else
+  ament_prepend_unique_value DYLD_LIBRARY_PATH "$_ODB_LIBRARY_DIR"
+fi
+unset _IS_DARWIN


### PR DESCRIPTION
  - Do this automatically when setup.sh is sourced
  - Ideally we'd provide a ROS wrapper package for ODB, but I this is maybe OK too

Prior to this change, if you built with ODB support, you'd have to manually add the odb lib directory to your LD_LIBRARY_PATH before perf_test would run.  The error was something like

```
/opt/PerformanceTest/lib/performance_test/perf_test: error while loading shared libraries: libodb-2.5.0-b.15.so: cannot open shared object file: No such file or directory
```

After this change, sourcing /opt/PerformanceTest/setup.bash is enough

Signed-off-by: Pete Baughman <pete.baughman@apex.ai>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/performance_test/109)
<!-- Reviewable:end -->
