### PR TITLE
Add checker for variance values saved into database

### DIFF
--- a/performance_test/src/experiment_execution/analysis_result.cpp
+++ b/performance_test/src/experiment_execution/analysis_result.cpp
@@ -35,9 +35,9 @@ AnalysisResult::AnalysisResult(
   const uint64_t num_samples_sent,
   const uint64_t num_samples_lost,
   const std::size_t total_data_received,
-  const StatisticsTracker latency,
-  const StatisticsTracker pub_loop_time_reserve,
-  const StatisticsTracker sub_loop_time_reserve,
+  StatisticsTracker latency,
+  StatisticsTracker pub_loop_time_reserve,
+  StatisticsTracker sub_loop_time_reserve,
   const CpuInfo cpu_info
 )
 : m_experiment_start(experiment_start),
@@ -183,5 +183,14 @@ std::string AnalysisResult::to_csv_string(const bool pretty_print, std::string s
 
   return ss.str();
 }
+
+#ifdef PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED
+void AnalysisResult::check_values()
+{
+  m_latency.check_value();
+  m_pub_loop_time_reserve.check_value();
+  m_sub_loop_time_reserve.check_value();
+}
+#endif
 
 }  // namespace performance_test

--- a/performance_test/src/experiment_execution/analysis_result.hpp
+++ b/performance_test/src/experiment_execution/analysis_result.hpp
@@ -108,9 +108,9 @@ public:
     const uint64_t num_samples_sent,
     const uint64_t num_samples_lost,
     const std::size_t total_data_received,
-    const StatisticsTracker latency,
-    const StatisticsTracker pub_loop_time_reserve,
-    const StatisticsTracker sub_loop_time_reserve,
+    StatisticsTracker latency,
+    StatisticsTracker pub_loop_time_reserve,
+    StatisticsTracker sub_loop_time_reserve,
     const CpuInfo cpu_info
   );
 #ifdef PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED
@@ -133,6 +133,8 @@ public:
   std::string to_csv_string(const bool pretty_print = false, std::string st = ",") const;
 
 #ifdef PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED
+  void check_values();
+
   void set_configuration(const ExperimentConfiguration * ec)
   {
     m_configuration = ec;
@@ -154,14 +156,17 @@ private:
   const uint64_t m_num_samples_lost = {};
   const std::size_t m_total_data_received = {};
 
-  const StatisticsTracker m_latency;
-  const StatisticsTracker m_pub_loop_time_reserve;
-  const StatisticsTracker m_sub_loop_time_reserve;
+  StatisticsTracker m_latency;
+  StatisticsTracker m_pub_loop_time_reserve;
+  StatisticsTracker m_sub_loop_time_reserve;
 #ifdef PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED
   RusageTracker m_sys_tracker;
 #pragma db transient
 #endif
   rusage m_sys_usage;
+#ifdef PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED
+#pragma db transient
+#endif
   const CpuInfo m_cpu_info;
 };
 

--- a/performance_test/src/experiment_execution/analyze_runner.cpp
+++ b/performance_test/src/experiment_execution/analyze_runner.cpp
@@ -190,7 +190,7 @@ void AnalyzeRunner::analyze(
   #ifdef PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED
   result->set_configuration(&m_ec);
   m_ec.get_results().push_back(result);
-
+  result->check_values();
   m_db->persist(result);
   #endif
 }

--- a/performance_test/src/utilities/statistics_tracker.hpp
+++ b/performance_test/src/utilities/statistics_tracker.hpp
@@ -89,6 +89,21 @@ public:
     m_M2 = var_t * (n_total - 1.0);
     m_variance = m_M2 / m_n;
   }
+
+#ifdef PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED
+// check if variables are not out of range or NaNs
+  void check_value()
+  {
+    if (m_variance > std::numeric_limits<double>::max()) {
+      m_variance = std::numeric_limits<double>::max();
+    } else if (m_variance < std::numeric_limits<double>::min()) {
+      m_variance = std::numeric_limits<double>::min();
+    } else if (std::isnan(std::abs(m_variance))) {
+      m_variance = std::numeric_limits<double>::max();
+    }
+  }
+#endif
+
   /// Adds a sample to consider in the metrics.
   void add_sample(const double x)
   {


### PR DESCRIPTION
This fixes the following error:
```
terminate called after throwing an instance of 'odb::mysql::database_exception' what(): 1264 (22003): Out of range value for column 'pub *loop* time *reserve* variance' at row 1
```
I'm adding a function to check if variance values are not out of range or nans, if so, I assign them to be std::numeric_limits<double>::max(); or std::numeric_limits<double>::min() -> so we can easly spot the outliers in the database.

The values are saved to the log files as before, I'm checking the variance just before saving to database.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/performance_test/111)
<!-- Reviewable:end -->
