### PR TITLE
Fix build on MacOS

### DIFF
--- a/performance_test/CMakeLists.txt
+++ b/performance_test/CMakeLists.txt
@@ -35,6 +35,15 @@ if(PERFORMANCE_TEST_FASTRTPS_ENABLED)
   add_definitions(-DPERFORMANCE_TEST_FASTRTPS_ENABLED)
 endif()
 
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  set(PERFORMANCE_TEST_RT_ENABLED_DEFAULT OFF)
+else()
+  set(PERFORMANCE_TEST_RT_ENABLED_DEFAULT ON)
+endif()
+option(PERFORMANCE_TEST_RT_ENABLED
+  "Enable options for thread and memory optimization. This may not build on all platforms"
+  PERFORMANCE_TEST_RT_ENABLED_DEFAULT)
+
 # Use ODB support to create SQL database
 option(PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED "Enable ODB for SQL" OFF)
 
@@ -194,11 +203,15 @@ set(sources
     src/experiment_configuration/qos_abstraction.cpp
     src/experiment_configuration/qos_abstraction.hpp
     src/experiment_configuration/experiment_configuration.cpp
-    src/utilities/rt_enabler.hpp
     src/utilities/spin_lock.hpp
     src/utilities/statistics_tracker.hpp
     src/utilities/cpu_usage_tracker.hpp
 )
+
+IF(PERFORMANCE_TEST_RT_ENABLED)
+  add_definitions(-DPERFORMANCE_TEST_RT_ENABLED)
+  list(APPEND sources src/utilities/rt_enabler.hpp)
+endif()
 
 # ROS2 Waitset
 option(PERFORMANCE_TEST_POLLING_SUBSCRIPTION_ENABLED "Option to enable Polling Subscription Plugin.

--- a/performance_test/src/experiment_configuration/experiment_configuration.cpp
+++ b/performance_test/src/experiment_configuration/experiment_configuration.cpp
@@ -246,10 +246,14 @@ void ExperimentConfiguration::setup(int argc, char ** argv)
       prio = 5;
       cpus = 62;
     }
-    if (prio != 0 || cpus != 0) {
-      pre_proc_rt_init(cpus, prio);
-      m_is_drivepx_rt = true;
-    }
+     if (prio != 0 || cpus != 0) {
+#if PERFORMANCE_TEST_RT_ENABLED
+       pre_proc_rt_init(cpus, prio);
+       m_is_drivepx_rt = true;
+#else
+       throw std::invalid_argument("Built with RT optimizations disabled");
+#endif
+     }
     m_use_single_participant = false;
     if (vm.count("use_single_participant")) {
       if (m_com_mean == CommunicationMean::ROS2) {

--- a/performance_test/src/experiment_configuration/experiment_configuration.hpp
+++ b/performance_test/src/experiment_configuration/experiment_configuration.hpp
@@ -25,7 +25,10 @@
 
 #include "qos_abstraction.hpp"
 #include "communication_mean.hpp"
+
+#if PERFORMANCE_TEST_RT_ENABLED
 #include "../utilities/rt_enabler.hpp"
+#endif
 
 #ifdef PERFORMANCE_TEST_ODB_FOR_SQL_ENABLED
   #include <odb/core.hxx>

--- a/performance_test/src/experiment_execution/analyze_runner.cpp
+++ b/performance_test/src/experiment_execution/analyze_runner.cpp
@@ -118,11 +118,13 @@ void AnalyzeRunner::run()
     std::for_each(m_pub_runners.begin(), m_pub_runners.end(), [](auto & a) {a->sync_reset();});
     std::for_each(m_sub_runners.begin(), m_sub_runners.end(), [](auto & a) {a->sync_reset();});
 
+    #if PERFORMANCE_TEST_RT_ENABLED
     /// Id drivepx_rt is set and this is the first loop, set the post RT init settings
     if (m_is_first_entry && m_ec.is_drivepx_rt()) {
       post_proc_rt_init();
       m_is_first_entry = false;
     }
+    #endif
 
     auto now = std::chrono::steady_clock::now();
     auto loop_diff_start = now - loop_start;

--- a/performance_test/src/utilities/rt_enabler.hpp
+++ b/performance_test/src/utilities/rt_enabler.hpp
@@ -16,7 +16,7 @@
 #define UTILITIES__RT_ENABLER_HPP_
 
 #include <sys/mman.h>
-#include <malloc.h>
+#include <cstdlib>
 #include <unistd.h>
 #include <sched.h>
 #include <sys/types.h>


### PR DESCRIPTION
The rt optimizations break on MacOS due to using weird calls to pthread (sched_setscheduler, which I don't even think works on a running thread) and mallopt, which doesn't exist on Mac.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/performance_test/113)
<!-- Reviewable:end -->
